### PR TITLE
Add keytar.findPasswordForService API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is a simple convenience function that internally calls
 
 Returns `true` on success, `false` on failure.
 
-### findPasswordForService(service)
+### findPassword(service)
 
 Find the first password for the `service` in the keychain.
 

--- a/spec/keytar-spec.coffee
+++ b/spec/keytar-spec.coffee
@@ -37,8 +37,8 @@ describe "keytar", ->
       expect(keytar.replacePassword(service, account, 'another secret')).toBe true
       expect(keytar.getPassword(service, account)).toBe 'another secret'
 
-  describe "findPasswordForService(service)", ->
+  describe "findPassword(service)", ->
     it "returns the first password for the service", ->
       expect(keytar.addPassword(service, account, password)).toBe true
       expect(keytar.addPassword(service, account2, password2)).toBe true
-      expect(keytar.findPasswordForService(service)).toBe password
+      expect(keytar.findPassword(service)).toBe password

--- a/src/keytar.coffee
+++ b/src/keytar.coffee
@@ -28,7 +28,7 @@ module.exports =
     keytar.deletePassword(service, account)
     keytar.addPassword(service, account, password)
 
-  findPasswordForService: (service) ->
+  findPassword: (service) ->
     throw new Error("Service is required.") unless service?.length > 0
 
-    keytar.findPasswordForService(service)
+    keytar.findPassword(service)

--- a/src/keytar.h
+++ b/src/keytar.h
@@ -13,11 +13,9 @@ bool GetPassword(const std::string& service,
                  const std::string& account,
                  std::string* password);
 
-bool DeletePassword(const std::string& service,
-                    const std::string& account);
+bool DeletePassword(const std::string& service, const std::string& account);
 
-bool FindPasswordForService(const std::string& service,
-                            std::string* password);
+bool FindPassword(const std::string& service, std::string* password);
 
 }  // namespace keytar
 

--- a/src/keytar_mac.cc
+++ b/src/keytar_mac.cc
@@ -39,8 +39,7 @@ bool GetPassword(const std::string& service,
   return true;
 }
 
-bool DeletePassword(const std::string& service,
-                    const std::string& account) {
+bool DeletePassword(const std::string& service, const std::string& account) {
   SecKeychainItemRef item;
   OSStatus status = SecKeychainFindGenericPassword(NULL,
                                                    service.length(),
@@ -58,8 +57,7 @@ bool DeletePassword(const std::string& service,
   return status == errSecSuccess;
 }
 
-bool FindPasswordForService(const std::string& service,
-                            std::string* password) {
+bool FindPassword(const std::string& service, std::string* password) {
   SecKeychainItemRef item;
   void *data;
   UInt32 length;

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -35,15 +35,13 @@ bool GetPassword(const std::string& service,
   return true;
 }
 
-bool DeletePassword(const std::string& service,
-                    const std::string& account) {
+bool DeletePassword(const std::string& service, const std::string& account) {
   std::string target_name = service + '/' + account;
 
   return ::CredDelete(target_name.c_str(), CRED_TYPE_GENERIC, 0) == TRUE;
 }
 
-bool FindPasswordForService(const std::string& service,
-                            std::string* password) {
+bool FindPassword(const std::string& service, std::string* password) {
   std::string filter = service + "*";
 
   DWORD count;

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,10 +29,9 @@ Handle<Value> DeletePassword(const Arguments& args) {
   return Boolean::New(success);
 }
 
-Handle<Value> FindPasswordForService(const Arguments& args) {
+Handle<Value> FindPassword(const Arguments& args) {
   std::string password;
-  bool success = keytar::FindPasswordForService(*String::Utf8Value(args[0]),
-                                                &password);
+  bool success = keytar::FindPassword(*String::Utf8Value(args[0]), &password);
   if (success)
     return String::New(password.data(), password.length());
   else
@@ -43,7 +42,7 @@ void Init(Handle<Object> exports) {
   NODE_SET_METHOD(exports, "getPassword", GetPassword);
   NODE_SET_METHOD(exports, "addPassword", AddPassword);
   NODE_SET_METHOD(exports, "deletePassword", DeletePassword);
-  NODE_SET_METHOD(exports, "findPasswordForService", FindPasswordForService);
+  NODE_SET_METHOD(exports, "findPassword", FindPassword);
 }
 
 }  // namespace


### PR DESCRIPTION
`keytar.findPasswordForService` can find the first password for the specified service, which is equivalent to the `security -q find-generic-password` command on OS X.
