### PR TITLE
Remove ci build target nodejs 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
 
 notifications:
   email: false


### PR DESCRIPTION
node-keytar does not build on 0.8 because [grunt-legacy-log-utils](https://www.npmjs.com/package/grunt-legacy-log-utils) does not support it.