### PR TITLE
Bump nan to version 2.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - CC=clang CXX=clang++ npm_config_clang=1
 
 node_js:
+  - "6.0"
+  - "4.0"
   - "0.11"
   - "0.10"
   - "iojs"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "grunt-coffeelint": "0.0.6"
   },
   "dependencies": {
-    "nan": "2.0.0"
+    "nan": "2.3.2"
   }
 }


### PR DESCRIPTION
Also, add Node 4.0 and Node 6.0 in the Travis test matrix.

Fixes #40.