### PR TITLE
Use libsecret instead of gnome-keyring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ env:
   - CC=clang CXX=clang++ npm_config_clang=1
 
 node_js:
+  - "7.0"
   - "6.0"
   - "4.0"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "0.12"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ node_js:
   - "7.0"
   - "6.0"
   - "4.0"
-  - "0.12"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 
-sudo: false
+dist: trusty
+sudo: required
 
-addons:
-  apt:
-    packages:
-      - xvfb
-      - gnome-keyring
-      - libgnome-keyring-dev
+before_install:
+- sudo apt-get update
+- sudo apt-get install xvfb gnome-keyring libsecret-1-dev
 
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Status](https://travis-ci.org/atom/node-keytar.svg?branch=master)](https://travi
 
 A native Node module to get, add, replace, and delete passwords in system's
 keychain. On OS X the passwords are managed by the Keychain, on Linux they are
-managed by Gnome Keyring and on Windows they are managed by Credential Vault.
+managed by the Secret Service API/libsecret, and on Windows they are managed by Credential Vault.
 
 ## Installing
 
@@ -15,9 +15,13 @@ npm install keytar
 
 ### On Linux
 
-Currently this library uses the gnome-keyring so you may need to run `sudo apt-get install libgnome-keyring-dev` before `npm install`ing.
+Currently this library uses `libsecret` so you may need to install it before `npm install`ing.
 
-If you are using a Red Hat-based system you need to run `sudo yum install libgnome-keyring-devel`.
+Depending on your distribution, you will need to run the following command:
+
+* Debian/Ubuntu: `sudo apt-get install libsecret-1-dev`
+* Red Hat-based: `sudo yum install libsecret-devel`
+* Arch Linux: `sudo pacman -S libsecret`
 
 ## Building
   * Clone the repository
@@ -61,7 +65,7 @@ Delete the stored password for the `service` and `account`.
 
 `account` - The string account name.
 
-Returns the string password or `null` on failures.
+Returns `true` if a password has been deleted, or `false` on failure.
 
 ### replacePassword(service, account, password)
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -33,16 +33,16 @@
             'src/keytar_posix.cc',
           ],
           'cflags': [
-            '<!(pkg-config --cflags gnome-keyring-1)',
+            '<!(pkg-config --cflags libsecret-1)',
             '-Wno-missing-field-initializers',
             '-Wno-deprecated-declarations',
           ],
           'link_settings': {
             'ldflags': [
-              '<!(pkg-config --libs-only-L --libs-only-other gnome-keyring-1)',
+              '<!(pkg-config --libs-only-L --libs-only-other libsecret-1)',
             ],
             'libraries': [
-              '<!(pkg-config --libs-only-l gnome-keyring-1)',
+              '<!(pkg-config --libs-only-l libsecret-1)',
             ],
           },
         }],

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+echo "starting dbus"
 sudo service dbus start
+echo "starting daemon"
 eval $(gnome-keyring-daemon)
+echo "exporting"
+echo $SSH_AUTH_SOCK
 export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK
 
+echo "testing"
 grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,7 +1,6 @@
 #!/bin/bash
-zz
+
 sudo service dbus start
 eval $(gnome-keyring-daemon)
-#export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK
-echo $SSH_AUTH_SOCK
+
 grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,12 +1,7 @@
 #!/bin/bash
-
-echo "starting dbus"
+zz
 sudo service dbus start
-echo "starting daemon"
 eval $(gnome-keyring-daemon)
-echo "exporting"
+#export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK
 echo $SSH_AUTH_SOCK
-export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK
-
-echo "testing"
 grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-sudo service dbus start
-eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --components=secrets --login)
-
-grunt test
+# grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sudo service dbus start
-eval $(gnome-keyring-daemon)
+eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --start --components=secrets --login)
 
 grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,5 +4,4 @@ sudo service dbus start
 eval $(gnome-keyring-daemon)
 export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK
 
-# FIXME Find out why we cound not connect to gnome-keyring-daemon.
-# grunt test
+grunt test

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sudo service dbus start
-eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --start --components=secrets --login)
+eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --components=secrets --login)
 
 grunt test

--- a/spec/keytar-spec.coffee
+++ b/spec/keytar-spec.coffee
@@ -1,6 +1,7 @@
 keytar = require '../lib/keytar'
-
+console.log "testing from grunt"
 describe "keytar", ->
+  console.log "describe"
   service = 'keytar tests'
   account = 'buster'
   password = 'secret'
@@ -8,15 +9,18 @@ describe "keytar", ->
   password2 = 'secret2'
 
   beforeEach ->
+    console.log "before"
     keytar.deletePassword(service, account)
     keytar.deletePassword(service, account2)
 
   afterEach ->
+    console.log "after"
     keytar.deletePassword(service, account)
     keytar.deletePassword(service, account2)
 
   describe "addPassword(service, account, password)", ->
     it "returns true when the service, account, and password are specified", ->
+      console.log "add pass"
       expect(keytar.addPassword(service, account, password)).toBe true
 
   describe "getPassword(service, account, password)", ->


### PR DESCRIPTION
This PR switches `keytar` to use `libsecret`.

This allows compatibility with any wallet/keyring implementing the [Secret Service API](https://specifications.freedesktop.org/secret-service) (including KWallet and GNOME Keyring)

The difference between this PR and #47 is that (in limited field testing) this one keeps compatibility with previously stored GNOME Keyring passwords.

This would supersede #46, #47 and close #17, #7.