### PR TITLE
Ignore .tags files and CI configuration in npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 *~
 .node-version
+.tags

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,6 @@
 *~
 .node-version
 .npmignore
+.tags
+.travis.yml
+appveyor.yml


### PR DESCRIPTION
keytar 4.0.2 includes a 14M `.tags` file:

```
$ du -s * .[^.]* | sort -nr
29360	.tags
1160	build
64	src
8	script
8	package.json
8	lib
8	binding.gyp
8	appveyor.yml
8	README.md
8	LICENSE.md
8	.travis.yml
8	.babelrc
```

Add `.tags` to `.gitignore` and `.npmignore` to (a) prevent this from happening in the future and (b) give us something to publish as 4.0.3 without that :wink:
