### PR TITLE
Support unicode account names on windows

### DIFF
--- a/spec/keytar-spec.js
+++ b/spec/keytar-spec.js
@@ -31,9 +31,9 @@ describe("keytar", function() {
     })
 
     describe("Unicode support", function() {
-      const service = "se®viçe"
-      const account = "shiƒ†ke¥"
-      const password = "påsswø®∂"
+      const service = "se®vi\u00C7e"
+      const account = "shi\u0191\u2020ke\u00A5"
+      const password = "p\u00E5ssw\u00D8®\u2202"
 
       it("handles unicode strings everywhere", async function() {
         await keytar.setPassword(service, account, password)

--- a/spec/keytar-spec.js
+++ b/spec/keytar-spec.js
@@ -29,6 +29,21 @@ describe("keytar", function() {
     it("yields null when the password was not found", async function() {
       assert.equal(await keytar.getPassword(service, account), null)
     })
+
+    describe("Unicode support", function() {
+      const service = "se®viçe"
+      const account = "shiƒ†ke¥"
+      const password = "påsswø®∂"
+
+      it("handles unicode strings everywhere", async function() {
+        await keytar.setPassword(service, account, password)
+        assert.equal(await keytar.getPassword(service, account), password)
+      })
+
+      afterEach(async function() {
+        await keytar.deletePassword(service, account)
+      })
+    })
   })
 
   describe("deletePassword(service, account)", function() {


### PR DESCRIPTION
`main.cc` convert v8 strings to utf8 but they were passed as ansi to windows. This PR convert the UTF-8 strings to windows UTF-16 before calling the credential store.

![2017-05-23 22_06_42-credential manager](https://cloud.githubusercontent.com/assets/131878/26374040/2425cbe0-4004-11e7-9516-f0d375d81a0d.png)

*Note*: This can stop applications that previously stored multibyte characters from getting old passwords correctly as it would change their encoding.

Original issue: https://github.com/desktop/desktop/issues/189