### PR TITLE
Malformed password argument leads to null pointer deference & segmentation fault

### DIFF
--- a/spec/keytar-spec.js
+++ b/spec/keytar-spec.js
@@ -9,6 +9,11 @@ describe("keytar", function() {
   var account2 = 'buster2'
   var password2 = 'secret2'
 
+  var object = {}
+  object.toString = function () {
+    throw new Error("Whoops! Time to seg fault")
+  }
+
   beforeEach(async function() {
     await keytar.deletePassword(service, account),
     await keytar.deletePassword(service, account2)
@@ -32,6 +37,52 @@ describe("keytar", function() {
 
     it("yields null when the password was not found", async function() {
       assert.equal(await keytar.getPassword(service, account), null)
+    })
+
+    describe("error handling", function () {
+      describe('setPassword', () => {
+        it("handles when an object is provided for service", async function () {
+          try {
+            await keytar.setPassword(object, account, password)
+          } catch (err) {
+            assert.equal(err.message, "Parameter 'service' must be a string")
+          }
+        })
+
+        it("handles when an object is provided for username", async function () {
+          try {
+            await keytar.setPassword(service, object, password)
+          } catch (err) {
+            assert.equal(err.message, "Parameter 'username' must be a string")
+          }
+        })
+
+        it("handles when an object is provided for password", async function () {
+          try {
+            await keytar.setPassword(service, account, object)
+          } catch (err) {
+            assert.equal(err.message, "Parameter 'password' must be a string")
+          }
+        })
+      })
+
+      describe('getPassword', () => {
+        it("handles when an object is provided for service", async function () {
+          try {
+            await keytar.getPassword(object, account)
+          } catch (err) {
+            assert.equal(err.message, "Parameter 'service' must be a string")
+          }
+        })
+
+        it("handles when an object is provided for username", async function () {
+          try {
+            await keytar.getPassword(service, object)
+          } catch (err) {
+            assert.equal(err.message, "Parameter 'username' must be a string")
+          }
+        })
+      })
     })
 
     describe("Unicode support", function() {
@@ -59,6 +110,24 @@ describe("keytar", function() {
     it("yields false when the password didn't exist", async function() {
       assert.equal(await keytar.deletePassword(service, account), false)
     })
+
+    describe("error handling", function () {
+      it("handles when an object is provided for service", async function () {
+        try {
+          await keytar.deletePassword(object, account)
+        } catch (err) {
+          assert.equal(err.message, "Parameter 'service' must be a string")
+        }
+      })
+
+      it("handles when an object is provided for username", async function () {
+        try {
+          await keytar.deletePassword(service, object)
+        } catch (err) {
+          assert.equal(err.message, "Parameter 'username' must be a string")
+        }
+      })
+    })
   })
 
   describe("findPassword(service)", function() {
@@ -70,6 +139,14 @@ describe("keytar", function() {
 
     it("yields null when no password can be found", async function() {
       assert.equal(await keytar.findPassword(service), null)
+    })
+
+    it("handles when an object is provided for service", async function () {
+      try {
+        await keytar.findPassword(object)
+      } catch (err) {
+        assert.equal(err.message, "Parameter 'service' must be a string")
+      }
     })
   })
 
@@ -90,6 +167,14 @@ describe("keytar", function() {
     it('returns an empty array when no credentials are found', async function() {
       const accounts = await keytar.findCredentials(service)
       assert.deepEqual([], accounts)
+    })
+
+    it("handles when an object is provided for service", async function () {
+      try {
+        await keytar.findCredentials(object)
+      } catch (err) {
+        assert.equal(err.message, "Parameter 'service' must be a string")
+      }
     })
 
     describe("Unicode support", function() {

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,10 +4,27 @@
 namespace {
 
 NAN_METHOD(SetPassword) {
+  if (!info[0]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'service' must be a string");
+    return;
+  }
+
   Nan::Utf8String serviceNan(info[0]);
   std::string service(*serviceNan, serviceNan.length());
+
+  if (!info[1]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'username' must be a string");
+    return;
+  }
+
   Nan::Utf8String usernameNan(info[1]);
   std::string username(*usernameNan, usernameNan.length());
+
+  if (!info[2]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'password' must be a string");
+    return;
+  }
+
   Nan::Utf8String passwordNan(info[2]);
   std::string password(*passwordNan, passwordNan.length());
 
@@ -20,8 +37,19 @@ NAN_METHOD(SetPassword) {
 }
 
 NAN_METHOD(GetPassword) {
+  if (!info[0]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'service' must be a string");
+    return;
+  }
+
   Nan::Utf8String serviceNan(info[0]);
   std::string service(*serviceNan, serviceNan.length());
+
+  if (!info[1]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'username' must be a string");
+    return;
+  }
+
   Nan::Utf8String usernameNan(info[1]);
   std::string username(*usernameNan, usernameNan.length());
 
@@ -33,8 +61,19 @@ NAN_METHOD(GetPassword) {
 }
 
 NAN_METHOD(DeletePassword) {
+  if (!info[0]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'service' must be a string");
+    return;
+  }
+
   Nan::Utf8String serviceNan(info[0]);
   std::string service(*serviceNan, serviceNan.length());
+
+  if (!info[1]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'username' must be a string");
+    return;
+  }
+
   Nan::Utf8String usernameNan(info[1]);
   std::string username(*usernameNan, usernameNan.length());
 
@@ -46,6 +85,11 @@ NAN_METHOD(DeletePassword) {
 }
 
 NAN_METHOD(FindPassword) {
+  if (!info[0]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'service' must be a string");
+    return;
+  }
+
   Nan::Utf8String serviceNan(info[0]);
   std::string service(*serviceNan, serviceNan.length());
 
@@ -56,6 +100,11 @@ NAN_METHOD(FindPassword) {
 }
 
 NAN_METHOD(FindCredentials) {
+  if (!info[0]->IsString()) {
+    Nan::ThrowTypeError("Parameter 'service' must be a string");
+    return;
+  }
+
   Nan::Utf8String serviceNan(info[0]);
   std::string service(*serviceNan, serviceNan.length());
 


### PR DESCRIPTION
👋 Was taking a look at the project w/ @philipturnbull and we came across a small issue in which a malformed password argument (specially one whose `toString()` method throws an exception) leads to a null pointer deference and segmentation fault. 

This does not pose a security risk but patching up this functionality could make `node-keytar` more robust 👍 

### Explanation 

**tl;dr** An error in `toString()` leads to node-keytar calling an std::string constructor w/ a null pointer which leads to undefined behavior (and seg faults for me).

All methods in `node-keytar` that cast a Javascript object (usually a `String` type) to `char *` rely on `v8::String::Utf8Value` which is a generally safe method to call. In the code, `v8::String::Utf8Value` is called with the `*` operator: [`*v8::String::Utf8Value(info[0]),`](https://github.com/atom/node-keytar/blob/62e471d21f45b5e1c54ee1104b209f4bcb3d83b5/src/main.cc#L8) which returns a `char *`. 

According to the [`v8::String::Utf8Value` documentation](https://github.com/nodejs/nan/blob/0c95010638219e55a9d85afcd9a58d425e3a0097/doc/v8_misc.md#nanutf8string):
>If conversion to a string fails (e.g. due to an exception in the toString() method of the object) then the length() method returns 0 and the * operator returns NULL.

However, `node-keytar` never checks to make sure this conversion was successful so when [`SetPasswordWorker`'s constructor is called](https://github.com/atom/node-keytar/blob/1181e4dc3e4bef2f6a73114cdef0b1863aec4c49/src/async.cc#L14-L17),  it calls `std::string`'s constructor with a null pointer: 
```
password(password) 

// This ^^^ is a weird C++ism but it means this:

this->password = std::string(password)
```
[Link to the code ^](https://github.com/atom/node-keytar/blob/1181e4dc3e4bef2f6a73114cdef0b1863aec4c49/src/async.cc#L17)

As explained in documentation C++
> If s is a null pointer, if n == npos, or if the range specified by [first,last) is not valid, it causes undefined behavior

In my build, I'm seeing the process seg fault. 

### Impact

There is very minimal impact unless a non-string type is being passed to `node-keytar`. Even so, this would just crash the process. I'm opening this issue to document this behavior and to show how unexpected javascript objects can cause problems in native modules in what seems like a sane implementation.

### Remediation 

To fix this issue, the C++ code should check that the result of calling `v8::String::Utf8Value` is non-null before passing on the result. 

/cc @BinaryMuse @philipturnbull @gregose 
