### PR TITLE
allow cross-compile for ARM, which requires static linking

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -47,6 +47,7 @@
             ],
           },
         }],
+        ['target_arch=="arm"', { 'type': 'static_library' }]
       ],
     }
   ]


### PR DESCRIPTION
Fixes #79 

Unfortunately, due to a lower-level linker failure, ARM builds must be compiled as astatic library.

This PR solves that by setting the target type to `static_library` when `target_arch=="arm"`.