### PR TITLE
Supported username on Windows

### DIFF
--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -91,6 +91,7 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
   cred.CredentialBlobSize = password.size();
   cred.CredentialBlob = (LPBYTE)(password.data());
   cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+  cred.UserName = utf8ToWideChar(account);
 
   bool result = ::CredWrite(&cred, 0);
   delete[] target_name;


### PR DESCRIPTION
Add username for credential data on Windows.

Before:
![before](https://user-images.githubusercontent.com/1855340/33597470-d693c6e4-d99f-11e7-9054-a20c3152e1a9.JPG)

After:
![after](https://user-images.githubusercontent.com/1855340/33597510-f22dea1a-d99f-11e7-94c0-03cfcf58a0b0.JPG)
