### PR TITLE
Remove static_library for arm architectures to build keytar.node also…

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -47,8 +47,7 @@
               '<!(pkg-config --libs-only-l libsecret-1)',
             ],
           },
-        }],
-        ['target_arch=="arm"', { 'type': 'static_library' }]
+        }]
       ],
     }
   ]


### PR DESCRIPTION
… on raspberry pi, see https://github.com/atom/node-keytar/issues/91