### PR TITLE
Fix FindCredentials size on windows

### DIFF
--- a/spec/keytar-spec.js
+++ b/spec/keytar-spec.js
@@ -92,8 +92,26 @@ describe("keytar", function() {
       assert.deepEqual([], accounts)
     })
 
-    afterEach(async function() {
-      await keytar.deletePassword(service2, account)
+    describe("Unicode support", function() {
+      const service = "se®vi\u00C7e"
+      const account = "shi\u0191\u2020ke\u00A5"
+      const password = "p\u00E5ssw\u00D8®\u2202"
+
+      it("handles unicode strings everywhere", async function() {
+        await keytar.setPassword(service, account, password)
+        await keytar.setPassword(service, account2, password2)
+
+        const found = await keytar.findCredentials(service)
+        const sorted = found.sort(function(a, b) {
+          return a.account.localeCompare(b.account)
+        })
+
+        assert.deepEqual([{account: account2, password: password2}, {account: account, password: password}], sorted)
+      })
+
+      afterEach(async function() {
+        await keytar.deletePassword(service, account)
+      })
     })
   });
 })

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -216,7 +216,7 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
     }
 
     std::string login = wideCharToAnsi(cred->UserName);
-    std::string password(reinterpret_cast<char*>(cred->CredentialBlob));
+    std::string password(reinterpret_cast<char*>(cred->CredentialBlob), cred->CredentialBlobSize);
 
     credentials->push_back(Credentials(login, password));
   }

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -216,7 +216,10 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
     }
 
     std::string login = wideCharToAnsi(cred->UserName);
-    std::string password(reinterpret_cast<char*>(cred->CredentialBlob), cred->CredentialBlobSize);
+    std::string password(
+      reinterpret_cast<char*>(
+        cred->CredentialBlob),
+        cred->CredentialBlobSize);
 
     credentials->push_back(Credentials(login, password));
   }

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -69,6 +69,41 @@ std::string wideCharToAnsi(LPWSTR wide_char) {
   return result;
 }
 
+std::string wideCharToUtf8(LPWSTR wide_char) {
+  if (wide_char == NULL) {
+    return std::string();
+  }
+
+  int utf8_length = WideCharToMultiByte(CP_UTF8,
+                                        0,
+                                        wide_char,
+                                        -1,
+                                        NULL,
+                                        0,
+                                        NULL,
+                                        NULL);
+  if (utf8_length == 0) {
+    return std::string();
+  }
+
+  char* buffer = new char[utf8_length];
+  if (WideCharToMultiByte(CP_UTF8,
+                          0,
+                          wide_char,
+                          -1,
+                          buffer,
+                          utf8_length,
+                          NULL,
+                          NULL) == 0) {
+    delete[] buffer;
+    return std::string();
+  }
+
+  std::string result = std::string(buffer);
+  delete[] buffer;
+  return result;
+}
+
 std::string getErrorMessage(DWORD errorCode) {
   LPWSTR errBuffer;
   ::FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -215,7 +250,7 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
       continue;
     }
 
-    std::string login = wideCharToAnsi(cred->UserName);
+    std::string login = wideCharToUtf8(cred->UserName);
     std::string password(
       reinterpret_cast<char*>(
         cred->CredentialBlob),


### PR DESCRIPTION
`FindCredentials` was missing passing the `CredentialBlobSize` which resulted in an extra character at the end of the password for some values. Fixes: https://github.com/atom/node-keytar/issues/96