### PR TITLE
Fix type definition file

### DIFF
--- a/keytar.d.ts
+++ b/keytar.d.ts
@@ -48,4 +48,4 @@ export declare function findPassword(service: string): Promise<string | null>;
  *
  * @returns A promise for the array of found credentials.
  */
-export declare function findCredentials(service: string): Promise<Array[{ account: string, password: string}]>;
+export declare function findCredentials(service: string): Promise<Array<{ account: string, password: string}>>;

--- a/keytar.d.ts
+++ b/keytar.d.ts
@@ -48,4 +48,4 @@ export declare function findPassword(service: string): Promise<string | null>;
  *
  * @returns A promise for the array of found credentials.
  */
-export declare function findCredentials(service: string): Promise<{ account: string, password: string}>;
+export declare function findCredentials(service: string): Promise<Array[{ account: string, password: string}]>;


### PR DESCRIPTION
The typescript type definition file has the wrong typing for findCredentials - this function returns an array, not a single object.

Fixes #102.