### PR TITLE
upgrade toolchain to node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 os:
   - linux
   - osx
-node_js: 8
+node_js: 9
 
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run --rm -v ${PWD}:/project electronuserland/electron-builder:8-ia32 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"; fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ branches:
 clone_depth: 10
 
 install:
-  - ps: Install-Product node 8 x64
+  - ps: Install-Product node 9 x64
   - npm install
 
 build_script:

--- a/docker/i386/Dockerfile
+++ b/docker/i386/Dockerfile
@@ -1,0 +1,20 @@
+FROM i386/debian:stretch
+
+RUN apt-get update
+RUN apt-get install --quiet --yes \
+    build-essential \
+    curl \
+    pkg-config \
+    clang \
+    python \
+    libsecret-1-dev
+
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+RUN apt-get install -y nodejs
+
+RUN node --version
+RUN npm --version
+
+ENV CC clang
+ENV CXX clang++
+ENV npm_config_clang 1

--- a/docker/i386/Dockerfile
+++ b/docker/i386/Dockerfile
@@ -12,9 +12,6 @@ RUN apt-get install --quiet --yes \
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y nodejs
 
-RUN node --version
-RUN npm --version
-
 ENV CC clang
 ENV CXX clang++
 ENV npm_config_clang 1


### PR DESCRIPTION
Before adding support for Node 10, this upgrades our toolchain to the latest Node 9 available for all supported platforms.

We're stopping here because Node 10 no longer distributes builds for 32-bit Linux distros - see https://github.com/nodesource/distributions/issues/680#issuecomment-401461560 for context - and building a Docker image for Node from source is non-trivial -  see #113 for that spike. 

Will follow up with other cleanup PRs to get things up to date. 