### PR TITLE
use Node 10 on CI for testing and packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 os:
   - linux
   - osx
-node_js: 9
+node_js: 10
 
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ branches:
 clone_depth: 10
 
 install:
-  - ps: Install-Product node 9 x64
+  - ps: Install-Product node 10 x64
   - npm install
 
 build_script:


### PR DESCRIPTION
No new `prebuild` targets, just ensuring everything runs fine on Node 10.

I'm leaving the 32-bit Linux `prebuild` steps on Node 9 to follow upstream support which has ceased at Node 10.0.