### PR TITLE
"Enterprise" persistence for Windows Credentials

### DIFF
--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -133,7 +133,7 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
   cred.UserName = user_name;
   cred.CredentialBlobSize = password.size();
   cred.CredentialBlob = (LPBYTE)(password.data());
-  cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+  cred.Persist = CRED_PERSIST_ENTERPRISE;
 
   bool result = ::CredWrite(&cred, 0);
   delete[] target_name;


### PR DESCRIPTION
This PR revises password storage on Microsoft Windows to claim "Enterprise" persistence instead of "Local Machine" persistence. This allows passwords to be roamed across enterprise networks, i.e. a certain single user will find his/her stored passwords when logging into different machines of the same network, should the administrator enable this.

This change should be reverse-compatible, as the credential manager will continue to find "old" entries with "Local Machine" persistence as well.

This PR closes #122.

**Before PR**
<img width="1125" alt="screen shot 2018-08-13 at 15 40 37" src="https://user-images.githubusercontent.com/36069303/44039912-74180868-9f1a-11e8-8da9-cb907b1bf7bd.png">

**After PR**
<img width="1125" alt="screen shot 2018-08-13 at 16 02 30" src="https://user-images.githubusercontent.com/36069303/44039960-8c4ab26e-9f1a-11e8-8dae-b7863664cf6e.png">