### PR TITLE
Allowing to change the location of keytar.node

### DIFF
--- a/lib/keytar.js
+++ b/lib/keytar.js
@@ -1,5 +1,3 @@
-var keytar = require('../build/Release/keytar.node')
-
 function checkRequired(val, name) {
   if (!val || val.length <= 0) {
     throw new Error(name + ' is required.');
@@ -22,12 +20,27 @@ function callbackPromise(callback) {
   }
 }
 
+var path = '../build/Release/keytar.node'
+var keytar
+
+function getKeytar() {
+  if(!keytar) {
+    keytar = require(path)
+  }
+
+  return
+}
+
 module.exports = {
+  setPath: function(keytar) {
+    path = keytar;
+  },
+
   getPassword: function (service, account) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
 
-    return callbackPromise(callback => keytar.getPassword(service, account, callback))
+    return callbackPromise(callback => getKeytar().getPassword(service, account, callback))
   },
 
   setPassword: function (service, account, password) {
@@ -35,25 +48,25 @@ module.exports = {
     checkRequired(account, 'Account')
     checkRequired(password, 'Password')
 
-    return callbackPromise(callback => keytar.setPassword(service, account, password, callback))
+    return callbackPromise(callback => getKeytar().setPassword(service, account, password, callback))
   },
 
   deletePassword: function (service, account) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
 
-    return callbackPromise(callback => keytar.deletePassword(service, account, callback))
+    return callbackPromise(callback => getKeytar().deletePassword(service, account, callback))
   },
 
   findPassword: function (service) {
     checkRequired(service, 'Service')
 
-    return callbackPromise(callback => keytar.findPassword(service, callback))
+    return callbackPromise(callback => getKeytar().findPassword(service, callback))
   },
 
   findCredentials: function (service) {
     checkRequired(service, 'Service')
 
-    return callbackPromise(callback => keytar.findCredentials(service, callback))
+    return callbackPromise(callback => getKeytar().findCredentials(service, callback))
   }
 }

--- a/lib/keytar.js
+++ b/lib/keytar.js
@@ -28,7 +28,7 @@ function getKeytar() {
     keytar = require(path)
   }
 
-  return
+  return keytar
 }
 
 module.exports = {


### PR DESCRIPTION
**Reason of this pr**:
There are package tools around like [nexe](https://github.com/nexe/nexe) or pkg. The only problem is, those tools can't handle native compiled addons (*.node) files.
However it is possible to include files in the binary (See https://github.com/nexe/nexe#resources). But the content can only be requested by using fs.readFile or fs.readFileSync in case of nexe.
Well, keytar requests the keytar.node statically and this won't be possible in combination with such tools. 

With this pr something like: https://github.com/gyselroth/tubee-client-cli/blob/dev/src/tubee.client.ts#L15-L19 gets possible now.