### PR TITLE
fix: Handle => Local for node 12 support

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -42,7 +42,7 @@ NAN_METHOD(FindCredentials) {
   Nan::AsyncQueueWorker(worker);
 }
 
-void Init(v8::Handle<v8::Object> exports) {
+void Init(v8::Local<v8::Object> exports) {
   Nan::SetMethod(exports, "getPassword", GetPassword);
   Nan::SetMethod(exports, "setPassword", SetPassword);
   Nan::SetMethod(exports, "deletePassword", DeletePassword);


### PR DESCRIPTION
v8::Handle is a deprecated alias for v8::Local.