### PR TITLE
refine workaround for node ABI issue with Electron install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@shiftkey/prebuild-install": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@shiftkey/prebuild-install/-/prebuild-install-5.2.2.tgz",
-      "integrity": "sha512-anP6PTWYX6ecAkRwILO6WO/uOhufDqQgCw9XRx7InzPQG6fYA5b2uhRzl7ClTxUUP5GzcighXNBHry9ZhbiC+w==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@shiftkey/prebuild-install/-/prebuild-install-5.2.4.tgz",
+      "integrity": "sha512-42L/pSGD/+diCg8SwhZaXjDlkAWV10u42UozyG7rqDdyPW7HDp2/j/RYRZ3x0sXFf7hAUtLYvI9HdACWdjyfVw==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -27,11 +27,6 @@
         "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
-        "expand-template": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -1017,6 +1012,11 @@
         "util-extend": "^1.0.1"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -1522,9 +1522,9 @@
       }
     },
     "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "nan": "2.8.0",
-    "@shiftkey/prebuild-install": "5.2.2"
+    "@shiftkey/prebuild-install": "5.2.4"
   }
 }


### PR DESCRIPTION
This builds upon #154 now that Electron has bumped the ABI for v4 to `69` in https://github.com/electron/node/commit/8bc5d171a0873c0ba49f9433798bc8b67399788c which is available in Electron [`4.0.4`](https://github.com/electron/electron/releases/tag/v4.0.4).

The patches applied to `prebuild-install` are here: https://github.com/prebuild/prebuild-install/compare/099c704fc6654637edf3a1ab4e85887fb150a5d7...8723b8b but the important part is the runtime check:

```js
if (rc.runtime === 'electron' && rc.target[0] === "4" && rc.abi === "64") {
  log.error(`Electron version ${rc.target} found - skipping prebuild-install work due to known ABI issue`)
  log.error('More information about this issue can be found at https://github.com/lgeiger/node-abi/issues/54')
  process.exit(1)
}
```

This check now means `prebuild-install` aborts when:

 - it's the Electron runtime
 - the target is in the `4.x.x` series
 - the ABI associated with it is the known incorrect one

TODO:

 - [x] test against `4.0.4` build -> ✅  (#157 will generate these with the next update)

```
prebuild-install WARN install No prebuilt binaries found (target=4.0.4 runtime=electron arch=x64 libc= platform=darwin)
```

 - [x] test against `4.0.3` build -> :x:

```
prebuild-install ERR! Electron version 4.0.3 found - skipping prebuild-install work due to known ABI issue
prebuild-install ERR! More information about this issue can be found at https://github.com/lgeiger/node-abi/issues/54
```

