### PR TITLE
upgrade node-abi and prebuild for newest v4 with correct Electron ABI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,9 +1657,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.1.tgz",
-      "integrity": "sha512-oDbFc7vCFx0RWWCweTer3hFm1u+e60N5FtGnmRV6QqvgATGFH/XRR6vqWIeBVosCYCqt6YdIr2L0exLZuEdVcQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.0.tgz",
+      "integrity": "sha512-egTtvNoZLMjwxkL/5iiJKYKZgn2im0zP+G+PncMxICYGiD3aZtXUvEsDmu0pF8gpASvLZyD8v53qi1/ELaRZpg==",
       "requires": {
         "semver": "^5.4.1"
       },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 6.11.0 -t 7.9.0 -t 8.9.0 -t 9.4.0 -t 10.11.0 --strip",
     "prebuild-node-ia32": "prebuild -t 6.11.0 -t 7.9.0 -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 4.0.4 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 4.0.4 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 6.11.0 -t 7.9.0 -t 8.9.0 -t 9.4.0 -t 10.11.0 --strip",
     "prebuild-node-ia32": "prebuild -t 6.11.0 -t 7.9.0 -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 4.0.4 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 4.0.4 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.4 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.4 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
-    "node-abi": "^2.5.1",
+    "node-abi": "^2.7.0",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^3.8.0",
     "prebuild": "^8.0.1"


### PR DESCRIPTION
Closes #133

`node-abi` now has support for the correct v4 Electron ABI https://github.com/lgeiger/node-abi/commit/9e4c1a63e63f8994cc2f5e3efee43785c9eb1c8f

This PR updates us to use that package and adds `4.0.4` as a target - after running `npm run prebuild-electron` locally I got an additional package with then new `v69` ABI, ready to go:

```
$ ls prebuilds                                                                                                                            
keytar-v4.3.1-electron-v53-darwin-x64.tar.gz	keytar-v4.3.1-electron-v57-darwin-x64.tar.gz	keytar-v4.3.1-electron-v69-darwin-x64.tar.gz
keytar-v4.3.1-electron-v54-darwin-x64.tar.gz	keytar-v4.3.1-electron-v64-darwin-x64.tar.gz
```