### PR TITLE
after publish ensure latest changes (and tags) are pushed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prebuild-node-ia32": "prebuild -t 6.11.0 -t 7.9.0 -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.4 -r electron --strip",
     "prebuild-electron-ia32": "prebuild -t 1.6.11 -t 1.7.10 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.4 -r electron -a ia32 --strip",
-    "upload": "node ./script/upload.js"
+    "upload": "node ./script/upload.js",
+    "postpublish": "git push --follow-tags"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
The tag associated with a release will trigger the prebuild process, and pushing the current branch means local commits are not accidentally left on the local machine.