### PR TITLE
restore appveyor setup to use x64 version of Node

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ branches:
 clone_depth: 10
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version x64
   - npm install
 
 build_script:


### PR DESCRIPTION
The hint to install x64 Node on Appveyor was removed accidentally in #190, which meant the prebuild scripts would only build for x86 Node and impacted users who didn't have their environment setup correctly.

Closes #196
Closes #195