### PR TITLE
Add electron v75 (7.0.0) to prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.3 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0-beta.3 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },


### PR DESCRIPTION
Just a simple addition of "-t 7.0.0-beta.3" that will cover all beta versions of 7.0.0. Can later be changed to "-t 7.0.0" as soon as the next major version of electron is officially released.