### PR TITLE
drop prebuild support for Electron 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },


### PR DESCRIPTION
With the release of Electron 7 last month and the PR to add prebuild support in #233 (currently on `beta` on NPM), this means Electron 4 is no longer receiving fixes or improvements.

Dropping prebuild support here to align with the upstream support lifecycle.