### PR TITLE
Fix: Check user_name after wchar conversion (Windows)

### DIFF
--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -123,7 +123,7 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
   }
 
   LPWSTR user_name = utf8ToWideChar(account);
-  if (target_name == NULL) {
+  if (user_name == NULL) {
     return FAIL_ERROR;
   }
 


### PR DESCRIPTION
### Identify the Bug

`SetPassword` converts the provided `std::string account` to a wchar-pointer by means of `utf8ToWideChar`. Subsequently, it should check if the conversion was successful.

Probably due to copy-paste, it checks `target_name` (again) instead.

### Description of the Change

Check the freshly created `user_name` instead.

### Alternate Designs

_None_

### Possible Drawbacks

_None_

### Verification Process

The code compiles.

### Release Notes

N/A
