### PR TITLE
Add support for electron 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^7.0.0",
-    "node-abi": "^2.13.0",
+    "node-abi": "^2.14.0",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^6.0.0",
     "prebuild": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },


### PR DESCRIPTION
Electron 8 has been released: 
https://github.com/electron/electron/releases/tag/v8.0.0

Seems that node-abi has already been updated in package-lock.json, so here i'm just syncing those.