### PR TITLE
On mac, use SecKeyChainItemModifyAttributesAndData instead of delete and add

### DIFF
--- a/src/keytar_mac.cc
+++ b/src/keytar_mac.cc
@@ -57,8 +57,7 @@ const std::string errorStatusToString(OSStatus status) {
 KEYTAR_OP_RESULT AddPassword(const std::string& service,
                              const std::string& account,
                              const std::string& password,
-                             std::string* error,
-                             bool returnNonfatalOnDuplicate) {
+                             std::string* error) {
   OSStatus status = SecKeychainAddGenericPassword(NULL,
                                                   service.length(),
                                                   service.data(),
@@ -68,9 +67,7 @@ KEYTAR_OP_RESULT AddPassword(const std::string& service,
                                                   password.data(),
                                                   NULL);
 
-  if (status == errSecDuplicateItem && returnNonfatalOnDuplicate) {
-    return FAIL_NONFATAL;
-  } else if (status != errSecSuccess) {
+  if (status != errSecSuccess) {
     *error = errorStatusToString(status);
     return FAIL_ERROR;
   }
@@ -82,16 +79,30 @@ KEYTAR_OP_RESULT SetPassword(const std::string& service,
                              const std::string& account,
                              const std::string& password,
                              std::string* error) {
-  KEYTAR_OP_RESULT result = AddPassword(service, account, password,
-                                        error, true);
-  if (result == FAIL_NONFATAL) {
-    // This password already exists, delete it and try again.
-    KEYTAR_OP_RESULT delResult = DeletePassword(service, account, error);
-    if (delResult == FAIL_ERROR)
-      return FAIL_ERROR;
-    else
-      return AddPassword(service, account, password, error, false);
-  } else if (result == FAIL_ERROR) {
+  SecKeychainItemRef item;
+  OSStatus result = SecKeychainFindGenericPassword(NULL,
+                                                   service.length(),
+                                                   service.data(),
+                                                   account.length(),
+                                                   account.data(),
+                                                   NULL,
+                                                   NULL,
+                                                   &item);
+
+  if (result == errSecItemNotFound) {
+    return AddPassword(service, account, password, error);
+  } else if (result != errSecSuccess) {
+    *error = errorStatusToString(result);
+    return FAIL_ERROR;
+  }
+
+  result = SecKeychainItemModifyAttributesAndData(item,
+                                                  NULL,
+                                                  password.length(),
+                                                  password.data());
+  CFRelease(item);
+  if (result != errSecSuccess) {
+    *error = errorStatusToString(result);
     return FAIL_ERROR;
   }
 


### PR DESCRIPTION
### Identify the Bug

Resolves https://github.com/atom/node-keytar/issues/120

### Description of the Change

Currently, in `setPassword` on Mac, the API for adding a password is called. If that fails, delete and add are called.

Instead of doing this, the [SecKeychainItemModifyAttributesAndData](https://developer.apple.com/documentation/security/1399963-seckeychainitemmodifyattributesa) API can be used to update the existing item. Now, `setPassword` first tries to find the password, and either adds it if it does not exist, or updates it if it does.

### Alternate Designs

_None_

### Possible Drawbacks

_None_

### Verification Process

I ran the existing tests.

### Release Notes

- Fixed an issue where simultaneous write and read to keychain on macOs would return null data
