### PR TITLE
get CodeQL analysis working with native node modules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,25 +34,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below).
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      with:
+        languages: javascript, cpp
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Install dependencies
       run: npm install
 
+    # Ensure node-gyp splats the required makefile and metadata to disk by rebuilding
+    - name: Build native module from source
+      run: ./node_modules/.bin/node-gyp rebuild
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,13 +11,21 @@ jobs:
     strategy:
       fail-fast: false
 
-
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+
+    # Install nodejs first
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+
+    # Setup dependencies (including native modules)
+    - name: Install dependencies
+      run: npm install
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,24 +18,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Install nodejs first
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
         languages: javascript, cpp
 
-    # Setup dependencies (including native modules)
+    # Setup dependencies (and build native modules from source)
     - name: Install dependencies
       run: npm install
 
-    # Ensure node-gyp splats the required makefile and metadata to disk by rebuilding
-    - name: Build native module from source
-      run: ./node_modules/.bin/node-gyp rebuild
-
+    # Run code analysis
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         node-version: '10.x'
 
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: javascript, cpp
+
     # Setup dependencies (including native modules)
     - name: Install dependencies
       run: npm install
@@ -30,12 +36,6 @@ jobs:
     # Ensure node-gyp splats the required makefile and metadata to disk by rebuilding
     - name: Build native module from source
       run: ./node_modules/.bin/node-gyp rebuild
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: javascript, cpp
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,12 @@ on:
 jobs:
   CodeQL-Build:
 
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-
-    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
-    runs-on: ubuntu-latest
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Builds upon #266 to see if we can get CodeQL analysis working for native modules.

The theory I want to prove or disprove is that we can get this working by installing the dependencies needed, which does a few things:

 - [x] populate the `node_modules` with the required packages, including `node-gyp`
 - [x] instead of the default behaviour of installing the prebuilt binary for the platform, force `node-gyp` to rebuild from source

```
$ ./node_modules/.bin/node-gyp rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@6.1.0
gyp info using node@12.16.2 | linux | x64
gyp info find Python using Python version 3.6.9 found at "/usr/bin/python3"
gyp info spawn /usr/bin/python3
gyp info spawn args [
gyp info spawn args   '/home/shiftkey/src/node-keytar/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/home/shiftkey/src/node-keytar/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/shiftkey/src/node-keytar/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/shiftkey/.cache/node-gyp/12.16.2/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/home/shiftkey/.cache/node-gyp/12.16.2',
gyp info spawn args   '-Dnode_gyp_dir=/home/shiftkey/src/node-keytar/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/home/shiftkey/.cache/node-gyp/12.16.2/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/home/shiftkey/src/node-keytar',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/home/shiftkey/src/node-keytar/build'
  CXX(target) Release/obj.target/keytar/src/async.o
  CXX(target) Release/obj.target/keytar/src/main.o
  CXX(target) Release/obj.target/keytar/src/keytar_posix.o
  SOLINK_MODULE(target) Release/obj.target/keytar.node
  COPY Release/keytar.node
make: Leaving directory '/home/shiftkey/src/node-keytar/build'
gyp info ok 

$ ls build
binding.Makefile  config.gypi  keytar.target.mk  Makefile  Release

$ ls build/Release/
keytar.node  obj.target
```

 - [x] run this after initializing CodeQL so that it detects our `cpp` source
 - [x] get this working on macOS and Windows too