### PR TITLE
migrate keytar to use n-api

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,16 @@
   'targets': [
     {
       'target_name': 'keytar',
-      'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      },
+      'msvs_settings': {
+        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+      },
+      'include_dirs' : [ "<!@(node -p \"require('node-addon-api').include\")" ],
       'sources': [
         'src/async.cc',
         'src/main.cc',

--- a/lib/keytar.js
+++ b/lib/keytar.js
@@ -6,28 +6,12 @@ function checkRequired(val, name) {
   }
 }
 
-function callbackPromise(callback) {
-  if (typeof callback === 'function') {
-    return new Promise(function(resolve, reject) {
-      callback((err, val) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(val)
-        }
-      })
-    })
-  } else {
-    throw new Error('Callback required')
-  }
-}
-
 module.exports = {
   getPassword: function (service, account) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
 
-    return callbackPromise(callback => keytar.getPassword(service, account, callback))
+    return keytar.getPassword(service, account)
   },
 
   setPassword: function (service, account, password) {
@@ -35,25 +19,25 @@ module.exports = {
     checkRequired(account, 'Account')
     checkRequired(password, 'Password')
 
-    return callbackPromise(callback => keytar.setPassword(service, account, password, callback))
+    return keytar.setPassword(service, account, password)
   },
 
   deletePassword: function (service, account) {
     checkRequired(service, 'Service')
     checkRequired(account, 'Account')
 
-    return callbackPromise(callback => keytar.deletePassword(service, account, callback))
+    return keytar.deletePassword(service, account)
   },
 
   findPassword: function (service) {
     checkRequired(service, 'Service')
 
-    return callbackPromise(callback => keytar.findPassword(service, callback))
+    return keytar.findPassword(service)
   },
 
   findCredentials: function (service) {
     checkRequired(service, 'Service')
 
-    return callbackPromise(callback => keytar.findCredentials(service, callback))
+    return keytar.findCredentials(service)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2114,11 +2114,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-    },
     "napi-build-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
@@ -2137,6 +2132,11 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz",
+      "integrity": "sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg=="
     },
     "node-cpplint": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prebuild": "^10.0.0"
   },
   "dependencies": {
-    "nan": "2.14.1",
+    "node-addon-api": "^3.0.0",
     "prebuild-install": "5.3.3"
   }
 }

--- a/src/async.cc
+++ b/src/async.cc
@@ -1,7 +1,8 @@
 #include <string>
 #include <vector>
 
-#include "nan.h"
+#include "napi.h"
+#include "uv.h"
 #include "keytar.h"
 #include "async.h"
 
@@ -11,13 +12,18 @@ SetPasswordWorker::SetPasswordWorker(
   const std::string& service,
   const std::string& account,
   const std::string& password,
-  Nan::Callback* callback
-) : AsyncWorker(callback),
+  const Napi::Env &env
+) : AsyncWorker(env),
     service(service),
     account(account),
-    password(password) {}
+    password(password),
+    deferred(Napi::Promise::Deferred::New(env)) {}
 
 SetPasswordWorker::~SetPasswordWorker() {}
+
+Napi::Promise SetPasswordWorker::Promise() {
+  return deferred.Promise();
+}
 
 void SetPasswordWorker::Execute() {
   std::string error;
@@ -26,21 +32,33 @@ void SetPasswordWorker::Execute() {
                                                 password,
                                                 &error);
   if (result == keytar::FAIL_ERROR) {
-    SetErrorMessage(error.c_str());
+    SetError(error.c_str());
   }
 }
 
+void SetPasswordWorker::OnOK() {
+  deferred.Resolve(Env().Undefined());
+}
+
+void SetPasswordWorker::OnError(Napi::Error const &error) {
+  deferred.Reject(error.Value());
+}
 
 
 GetPasswordWorker::GetPasswordWorker(
   const std::string& service,
   const std::string& account,
-  Nan::Callback* callback
-) : AsyncWorker(callback),
+  const Napi::Env &env
+) : AsyncWorker(env),
     service(service),
-    account(account) {}
+    account(account),
+    deferred(Napi::Promise::Deferred::New(env)) {}
 
 GetPasswordWorker::~GetPasswordWorker() {}
+
+Napi::Promise GetPasswordWorker::Promise() {
+  return deferred.Promise();
+}
 
 void GetPasswordWorker::Execute() {
   std::string error;
@@ -49,7 +67,7 @@ void GetPasswordWorker::Execute() {
                                                 &password,
                                                 &error);
   if (result == keytar::FAIL_ERROR) {
-    SetErrorMessage(error.c_str());
+    SetError(error.c_str());
   } else if (result == keytar::FAIL_NONFATAL) {
     success = false;
   } else {
@@ -57,38 +75,39 @@ void GetPasswordWorker::Execute() {
   }
 }
 
-void GetPasswordWorker::HandleOKCallback() {
-  Nan::HandleScope scope;
-  v8::Local<v8::Value> val = Nan::Null();
+void GetPasswordWorker::OnOK() {
+  Napi::Value val = Env().Null();
   if (success) {
-    val = Nan::New<v8::String>(password.data(),
-                               password.length()).ToLocalChecked();
+    val = Napi::String::New(Env(), password.data(),
+                               password.length());
   }
-  v8::Local<v8::Value> argv[] = {
-    Nan::Null(),
-    val
-  };
-
-  callback->Call(2, argv, async_resource);
+  deferred.Resolve(val);
 }
 
-
+void GetPasswordWorker::OnError(Napi::Error const &error) {
+  deferred.Reject(error.Value());
+}
 
 DeletePasswordWorker::DeletePasswordWorker(
   const std::string& service,
   const std::string& account,
-  Nan::Callback* callback
-) : AsyncWorker(callback),
+  const Napi::Env &env
+) : AsyncWorker(env),
     service(service),
-    account(account) {}
+    account(account),
+    deferred(Napi::Promise::Deferred::New(env)) {}
 
 DeletePasswordWorker::~DeletePasswordWorker() {}
+
+Napi::Promise DeletePasswordWorker::Promise() {
+  return deferred.Promise();
+}
 
 void DeletePasswordWorker::Execute() {
   std::string error;
   KEYTAR_OP_RESULT result = keytar::DeletePassword(service, account, &error);
   if (result == keytar::FAIL_ERROR) {
-    SetErrorMessage(error.c_str());
+    SetError(error.c_str());
   } else if (result == keytar::FAIL_NONFATAL) {
     success = false;
   } else {
@@ -96,27 +115,26 @@ void DeletePasswordWorker::Execute() {
   }
 }
 
-void DeletePasswordWorker::HandleOKCallback() {
-  Nan::HandleScope scope;
-  v8::Local<v8::Boolean> val =
-    Nan::New<v8::Boolean>(success);
-  v8::Local<v8::Value> argv[] = {
-    Nan::Null(),
-    val
-  };
-
-  callback->Call(2, argv, async_resource);
+void DeletePasswordWorker::OnOK() {
+  deferred.Resolve(Napi::Boolean::New(Env(), success));
 }
 
-
+void DeletePasswordWorker::OnError(Napi::Error const &error) {
+  deferred.Reject(error.Value());
+}
 
 FindPasswordWorker::FindPasswordWorker(
   const std::string& service,
-  Nan::Callback* callback
-) : AsyncWorker(callback),
-    service(service) {}
+  const Napi::Env &env
+) : AsyncWorker(env),
+    service(service),
+    deferred(Napi::Promise::Deferred::New(env)) {}
 
 FindPasswordWorker::~FindPasswordWorker() {}
+
+Napi::Promise FindPasswordWorker::Promise() {
+  return deferred.Promise();
+}
 
 void FindPasswordWorker::Execute() {
   std::string error;
@@ -124,7 +142,7 @@ void FindPasswordWorker::Execute() {
                                                  &password,
                                                  &error);
   if (result == keytar::FAIL_ERROR) {
-    SetErrorMessage(error.c_str());
+    SetError(error.c_str());
   } else if (result == keytar::FAIL_NONFATAL) {
     success = false;
   } else {
@@ -132,30 +150,31 @@ void FindPasswordWorker::Execute() {
   }
 }
 
-void FindPasswordWorker::HandleOKCallback() {
-  Nan::HandleScope scope;
-  v8::Local<v8::Value> val = Nan::Null();
+void FindPasswordWorker::OnOK() {
+  Napi::Value val = Env().Null();
   if (success) {
-    val = Nan::New<v8::String>(password.data(),
-                               password.length()).ToLocalChecked();
+    val = Napi::String::New(Env(), password.data(),
+                               password.length());
   }
-  v8::Local<v8::Value> argv[] = {
-    Nan::Null(),
-    val
-  };
-
-  callback->Call(2, argv, async_resource);
+  deferred.Resolve(val);
 }
 
-
+void FindPasswordWorker::OnError(Napi::Error const &error) {
+  deferred.Reject(error.Value());
+}
 
 FindCredentialsWorker::FindCredentialsWorker(
   const std::string& service,
-  Nan::Callback* callback
-) : AsyncWorker(callback),
-    service(service) {}
+  const Napi::Env &env
+) : AsyncWorker(env),
+    service(service),
+    deferred(Napi::Promise::Deferred::New(env)) {}
 
 FindCredentialsWorker::~FindCredentialsWorker() {}
+
+Napi::Promise FindCredentialsWorker::Promise() {
+  return deferred.Promise();
+}
 
 void FindCredentialsWorker::Execute() {
   std::string error;
@@ -163,7 +182,7 @@ void FindCredentialsWorker::Execute() {
                                                     &credentials,
                                                     &error);
   if (result == keytar::FAIL_ERROR) {
-    SetErrorMessage(error.c_str());
+    SetError(error.c_str());
   } else if (result == keytar::FAIL_NONFATAL) {
     success = false;
   } else {
@@ -171,54 +190,44 @@ void FindCredentialsWorker::Execute() {
   }
 }
 
-void FindCredentialsWorker::HandleOKCallback() {
-  Nan::HandleScope scope;
+void FindCredentialsWorker::OnOK() {
+  Napi::Env env = Env();
 
   if (success) {
-    v8::Local<v8::Array> val = Nan::New<v8::Array>(credentials.size());
+    Napi::Array val = Napi::Array::New(env, credentials.size());
     unsigned int idx = 0;
     std::vector<keytar::Credentials>::iterator it;
     for (it = credentials.begin(); it != credentials.end(); it++) {
       keytar::Credentials cred = *it;
-      v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+      Napi::Object obj = Napi::Object::New(env);
 
-      v8::Local<v8::String> account = Nan::New<v8::String>(
+      Napi::String account = Napi::String::New(env,
         cred.first.data(),
-        cred.first.length()).ToLocalChecked();
+        cred.first.length());
 
-      v8::Local<v8::String> password = Nan::New<v8::String>(
+      Napi::String password = Napi::String::New(env,
         cred.second.data(),
-        cred.second.length()).ToLocalChecked();
+        cred.second.length());
 
 #ifndef _WIN32
 #pragma GCC diagnostic ignored "-Wunused-result"
 #endif
-      obj->Set(
-        Nan::GetCurrentContext(),
-        Nan::New("account").ToLocalChecked(),
-        account);
+      obj.Set("account", account);
 #ifndef _WIN32
 #pragma GCC diagnostic ignored "-Wunused-result"
 #endif
-      obj->Set(
-        Nan::GetCurrentContext(),
-        Nan::New("password").ToLocalChecked(),
-        password);
+      obj.Set("password", password);
 
-      Nan::Set(val, idx, obj);
+      (val).Set(idx, obj);
       ++idx;
     }
 
-    v8::Local<v8::Value> argv[] = {
-      Nan::Null(),
-      val
-    };
-    callback->Call(2, argv, async_resource);
+    deferred.Resolve(val);
   } else {
-    v8::Local<v8::Value> argv[] = {
-      Nan::Null(),
-      Nan::New<v8::Array>(0)
-    };
-    callback->Call(2, argv, async_resource);
+    deferred.Resolve(Napi::Array::New(env, 0));
   }
+}
+
+void FindCredentialsWorker::OnError(Napi::Error const &error) {
+  deferred.Reject(error.Value());
 }

--- a/src/async.h
+++ b/src/async.h
@@ -2,84 +2,103 @@
 #define SRC_ASYNC_H_
 
 #include <string>
-#include "nan.h"
+#include "napi.h"
+#include "uv.h"
 
 #include "credentials.h"
 
-class SetPasswordWorker : public Nan::AsyncWorker {
+class SetPasswordWorker : public Napi::AsyncWorker {
   public:
     SetPasswordWorker(const std::string& service, const std::string& account, const std::string& password,
-                      Nan::Callback* callback);
+                      const Napi::Env &env);
 
     ~SetPasswordWorker();
 
     void Execute();
+    void OnOK();
+    void OnError(Napi::Error const &error);
+    Napi::Promise Promise();
 
   private:
     const std::string service;
     const std::string account;
     const std::string password;
+    Napi::Promise::Deferred deferred;
 };
 
-class GetPasswordWorker : public Nan::AsyncWorker {
+class GetPasswordWorker : public Napi::AsyncWorker {
   public:
-    GetPasswordWorker(const std::string& service, const std::string& account, Nan::Callback* callback);
+    GetPasswordWorker(const std::string& service, const std::string& account,
+                      const Napi::Env &env);
 
     ~GetPasswordWorker();
 
     void Execute();
-    void HandleOKCallback();
+    void OnOK();
+    void OnError(Napi::Error const &error);
+    Napi::Promise Promise();
 
   private:
     const std::string service;
     const std::string account;
     std::string password;
     bool success;
+    const Napi::Promise::Deferred deferred;
 };
 
-class DeletePasswordWorker : public Nan::AsyncWorker {
+class DeletePasswordWorker : public Napi::AsyncWorker {
   public:
-    DeletePasswordWorker(const std::string& service, const std::string& account, Nan::Callback* callback);
+    DeletePasswordWorker(const std::string& service, const std::string& account,
+                         const Napi::Env &env);
 
     ~DeletePasswordWorker();
 
     void Execute();
-    void HandleOKCallback();
+    void OnOK();
+    void OnError(Napi::Error const &error);
+    Napi::Promise Promise();
 
   private:
     const std::string service;
     const std::string account;
     bool success;
+    Napi::Promise::Deferred deferred;
 };
 
-class FindPasswordWorker : public Nan::AsyncWorker {
+class FindPasswordWorker : public Napi::AsyncWorker {
   public:
-    FindPasswordWorker(const std::string& service, Nan::Callback* callback);
+    FindPasswordWorker(const std::string& service, const Napi::Env &env);
 
     ~FindPasswordWorker();
 
     void Execute();
-    void HandleOKCallback();
+    void OnOK();
+    void OnError(Napi::Error const &error);
+    Napi::Promise Promise();
 
   private:
     const std::string service;
     std::string password;
     bool success;
+    const Napi::Promise::Deferred deferred;
 };
 
-class FindCredentialsWorker : public Nan::AsyncWorker {
+class FindCredentialsWorker : public Napi::AsyncWorker {
   public:
-    FindCredentialsWorker(const std::string& service, Nan::Callback* callback);
+    FindCredentialsWorker(const std::string& service, const Napi::Env &env);
 
     ~FindCredentialsWorker();
 
     void Execute();
-    void HandleOKCallback();
+    void OnOK();
+    void OnError(Napi::Error const &error);
+    Napi::Promise Promise();
 
   private:
     const std::string service;
     std::vector<keytar::Credentials> credentials;
     bool success;
+    const Napi::Promise::Deferred deferred;
 };
 
 #endif  // SRC_ASYNC_H_

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,131 +1,139 @@
-#include "nan.h"
+#include "napi.h"
+#include "uv.h"
 #include "async.h"
 
 namespace {
 
-NAN_METHOD(SetPassword) {
-  if (!info[0]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'service' must be a string");
-    return;
+Napi::Value SetPassword(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'service' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String serviceNan(info[0]);
-  std::string service(*serviceNan, serviceNan.length());
+  std::string service = info[0].As<Napi::String>();
 
-  if (!info[1]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'username' must be a string");
-    return;
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'username' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String usernameNan(info[1]);
-  std::string username(*usernameNan, usernameNan.length());
+  std::string username = info[1].As<Napi::String>();
 
-  if (!info[2]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'password' must be a string");
-    return;
+  if (!info[2].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'password' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String passwordNan(info[2]);
-  std::string password(*passwordNan, passwordNan.length());
+  std::string password = info[2].As<Napi::String>();
 
   SetPasswordWorker* worker = new SetPasswordWorker(
     service,
     username,
     password,
-    new Nan::Callback(info[3].As<v8::Function>()));
-  Nan::AsyncQueueWorker(worker);
+    env);
+  worker->Queue();
+  return worker->Promise();
 }
 
-NAN_METHOD(GetPassword) {
-  if (!info[0]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'service' must be a string");
-    return;
+Napi::Value GetPassword(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'service' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String serviceNan(info[0]);
-  std::string service(*serviceNan, serviceNan.length());
+  std::string service = info[0].As<Napi::String>();
 
-  if (!info[1]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'username' must be a string");
-    return;
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'username' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String usernameNan(info[1]);
-  std::string username(*usernameNan, usernameNan.length());
+  std::string username = info[1].As<Napi::String>();
 
   GetPasswordWorker* worker = new GetPasswordWorker(
     service,
     username,
-    new Nan::Callback(info[2].As<v8::Function>()));
-  Nan::AsyncQueueWorker(worker);
+    env);
+  worker->Queue();
+  return worker->Promise();
 }
 
-NAN_METHOD(DeletePassword) {
-  if (!info[0]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'service' must be a string");
-    return;
+Napi::Value DeletePassword(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'service' must be a string");
+    return env.Null();
   }
 
-  Nan::Utf8String serviceNan(info[0]);
-  std::string service(*serviceNan, serviceNan.length());
+  std::string service = info[0].As<Napi::String>();
 
-  if (!info[1]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'username' must be a string");
-    return;
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'username' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String usernameNan(info[1]);
-  std::string username(*usernameNan, usernameNan.length());
+  std::string username = info[1].As<Napi::String>();
 
-  DeletePasswordWorker* worker = new DeletePasswordWorker(
+  DeletePasswordWorker *worker = new DeletePasswordWorker(
     service,
     username,
-    new Nan::Callback(info[2].As<v8::Function>()));
-  Nan::AsyncQueueWorker(worker);
+    env);
+  worker->Queue();
+  return worker->Promise();
 }
 
-NAN_METHOD(FindPassword) {
-  if (!info[0]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'service' must be a string");
-    return;
+Napi::Value FindPassword(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'service' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String serviceNan(info[0]);
-  std::string service(*serviceNan, serviceNan.length());
+  std::string service = info[0].As<Napi::String>();
 
   FindPasswordWorker* worker = new FindPasswordWorker(
     service,
-    new Nan::Callback(info[1].As<v8::Function>()));
-  Nan::AsyncQueueWorker(worker);
+    env);
+  worker->Queue();
+  return worker->Promise();
 }
 
-NAN_METHOD(FindCredentials) {
-  if (!info[0]->IsString()) {
-    Nan::ThrowTypeError("Parameter 'service' must be a string");
-    return;
+Napi::Value FindCredentials(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Parameter 'service' must be a string").
+      ThrowAsJavaScriptException();
+    return env.Null();
   }
 
-  Nan::Utf8String serviceNan(info[0]);
-  std::string service(*serviceNan, serviceNan.length());
+  std::string service = info[0].As<Napi::String>();
 
   FindCredentialsWorker* worker = new FindCredentialsWorker(
     service,
-    new Nan::Callback(info[1].As<v8::Function>()));
-  Nan::AsyncQueueWorker(worker);
+    env);
+  worker->Queue();
+  return worker->Promise();
 }
 
-NAN_MODULE_INIT(Init) {
-  Nan::SetMethod(target, "getPassword", GetPassword);
-  Nan::SetMethod(target, "setPassword", SetPassword);
-  Nan::SetMethod(target, "deletePassword", DeletePassword);
-  Nan::SetMethod(target, "findPassword", FindPassword);
-  Nan::SetMethod(target, "findCredentials", FindCredentials);
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("getPassword", Napi::Function::New(env, GetPassword));
+  exports.Set("setPassword", Napi::Function::New(env, SetPassword));
+  exports.Set("deletePassword", Napi::Function::New(env, DeletePassword));
+  exports.Set("findPassword", Napi::Function::New(env, FindPassword));
+  exports.Set("findCredentials", Napi::Function::New(env, FindCredentials));
+  return exports;
 }
 
 }  // namespace
 
-#if NODE_MAJOR_VERSION >= 10
-NAN_MODULE_WORKER_ENABLED(keytar, Init)
-#else
-NODE_MODULE(keytar, Init)
-#endif
+NODE_API_MODULE(keytar, Init)


### PR DESCRIPTION
This PR migrates keytar from nan to [N-API](https://nodejs.org/dist/latest-v14.x/docs/api/n-api.html#n_api_n_api) via the [node-addon-api module](https://github.com/nodejs/node-addon-api).

Migrating to N-API provides ABI stability meaning that versions of keytar compiled for one major version can run on later major versions of Node.js without recompilation.  This means that issues like #174 would be non-issues in the future.