### PR TITLE
fixup deletePassword to properly throw an error

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -69,7 +69,8 @@ Napi::Value GetPassword(const Napi::CallbackInfo& info) {
 Napi::Value DeletePassword(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (!info[0].IsString()) {
-    Napi::TypeError::New(env, "Parameter 'service' must be a string");
+    Napi::TypeError::New(env, "Parameter 'service' must be a string").
+      ThrowAsJavaScriptException();
     return env.Null();
   }
 


### PR DESCRIPTION
This is a followup to #268.  As @vadim-termius properly noted here: https://github.com/atom/node-keytar/pull/268#discussion_r423016030, DeletePassword should throw a Javascript exception if the service parameter isn't a string, so this PR fixes that issue.