### PR TITLE
add prebuild support for Electron 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2126,9 +2126,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
-      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.17.0.tgz",
+      "integrity": "sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==",
       "requires": {
         "semver": "^5.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0-beta.16 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0-beta.16 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^7.1.2",
-    "node-abi": "^2.16.0",
+    "node-abi": "^2.17.0",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^6.0.0",
     "prebuild": "^10.0.0"


### PR DESCRIPTION
### Identify the Bug

I'm fixing the bug which prevents the build of the native module with the latest electron 9 (#271).

### Description of the Change

I updated the `node-abi` dependency to `2.17.0`

### Alternate Designs

None

### Possible Drawbacks

Can't think of any

### Verification Process

I ran the `prebuild-electron` script to check if the package now builds for electron 9

### Release Notes

Not applicable