### PR TITLE
drop unnecessary includes to preserve ABI compatibility

### DIFF
--- a/src/async.cc
+++ b/src/async.cc
@@ -2,7 +2,6 @@
 #include <vector>
 
 #include "napi.h"
-#include "uv.h"
 #include "keytar.h"
 #include "async.h"
 

--- a/src/async.h
+++ b/src/async.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include "napi.h"
-#include "uv.h"
 
 #include "credentials.h"
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,5 +1,4 @@
 #include "napi.h"
-#include "uv.h"
 #include "async.h"
 
 namespace {


### PR DESCRIPTION
Related to https://github.com/atom/node-keytar/pull/268#issuecomment-633174756

https://nodejs.org/dist/latest-v14.x/docs/api/n-api.html#n_api_implications_of_abi_stability indicates that including some headers may violate the ABI guarantees, and `uv.h` was included in that list. I can't spot anything obvious that uses this, so let's see if we can drop these includes to avoid any potential headaches down the track.

 - [x] confirm builds pass on all platforms

cc @jkleinsc @vadim-termius for 👍 or 👎 