### PR TITLE
Return service from findCredentials invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Find all accounts and password for the `service` in the keychain.
 
 `service` - The string service name.
 
-Yields an array of `{ account: 'foo', password: 'bar' }`.
+Yields an array of `{ service: 'foo', account: 'bar', password: 'baz' }`.
 
 ### findPassword(service)
 

--- a/keytar.d.ts
+++ b/keytar.d.ts
@@ -48,4 +48,4 @@ export declare function findPassword(service: string): Promise<string | null>;
  *
  * @returns A promise for the array of found credentials.
  */
-export declare function findCredentials(service: string): Promise<Array<{ account: string, password: string}>>;
+export declare function findCredentials(service: string): Promise<Array<{ service: string, account: string, password: string}>>;

--- a/spec/keytar-spec.js
+++ b/spec/keytar-spec.js
@@ -161,7 +161,10 @@ describe("keytar", function() {
         return a.account.localeCompare(b.account)
       })
 
-      assert.deepEqual([{account: account, password: password}, {account: account2, password: password2}], sorted)
+      assert.deepEqual([
+        { service: service, account: account, password: password },
+        { service: service, account: account2, password: password2 }
+      ], sorted)
     });
 
     it('returns an empty array when no credentials are found', async function() {
@@ -191,7 +194,10 @@ describe("keytar", function() {
           return a.account.localeCompare(b.account)
         })
 
-        assert.deepEqual([{account: account2, password: password2}, {account: account, password: password}], sorted)
+        assert.deepEqual([
+          { service: service, account: account2, password: password2 },
+          { service: service, account: account, password: password }
+        ], sorted)
       })
 
       afterEach(async function() {

--- a/src/async.cc
+++ b/src/async.cc
@@ -200,14 +200,22 @@ void FindCredentialsWorker::OnOK() {
       keytar::Credentials cred = *it;
       Napi::Object obj = Napi::Object::New(env);
 
+      Napi::String service = Napi::String::New(env,
+	std::get<0>(cred).data(),
+	std::get<0>(cred).length());
+
       Napi::String account = Napi::String::New(env,
-        cred.first.data(),
-        cred.first.length());
+	std::get<1>(cred).data(),
+	std::get<1>(cred).length());
 
       Napi::String password = Napi::String::New(env,
-        cred.second.data(),
-        cred.second.length());
+	std::get<2>(cred).data(),
+	std::get<2>(cred).length());
 
+#ifndef _WIN32
+#pragma GCC diagnostic ignored "-Wunused-result"
+#endif
+      obj.Set("service", service);
 #ifndef _WIN32
 #pragma GCC diagnostic ignored "-Wunused-result"
 #endif

--- a/src/credentials.h
+++ b/src/credentials.h
@@ -2,11 +2,11 @@
 #define SRC_CREDENTIALS_H_
 
 #include <string>
-#include <utility>
+#include <tuple>
 
 namespace keytar {
 
-typedef std::pair<std::string, std::string> Credentials;
+typedef std::tuple<std::string, std::string, std::string> Credentials;
 
 }
 

--- a/src/keytar_mac.cc
+++ b/src/keytar_mac.cc
@@ -226,6 +226,7 @@ Credentials getCredentialsForItem(CFDictionaryRef item) {
         kCFStringEncodingUTF8);
 
       Credentials cred = Credentials(
+	CFStringToStdString(service),
         CFStringToStdString(account),
         CFStringToStdString(password));
       CFRelease(password);

--- a/src/keytar_posix.cc
+++ b/src/keytar_posix.cc
@@ -173,7 +173,7 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
       continue;
     }
 
-    credentials->push_back(Credentials(account, password));
+    credentials->push_back(Credentials(service, account, password));
     free(account);
     free(password);
   }

--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -256,7 +256,7 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
         cred->CredentialBlob),
         cred->CredentialBlobSize);
 
-    credentials->push_back(Credentials(login, password));
+    credentials->push_back(Credentials(service, login, password));
   }
 
   CredFree(creds);


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom/node-keytar/issues/144

### Description of the Change

These changes add the `service` property to the result of the findCredentials method, introduced by https://github.com/atom/node-keytar/pull/85.

### Alternate Designs

Other alternative solutions would be the use of std::array instead of std::tuple for the definition of `Credentials` in `credentials.h` seeing as the values used up until this point are homogenous. I decided to stick with Tuple since it's a generalization of the previously used std::pair. I'm open to tweaking the code as needed, pending review, to highlight any potential issues. C++ is not a language I'm well versed in.

### Possible Drawbacks

Possible side effects are a slight increase in memory usage in order to support the return of the `service` property.

### Verification Process

- The program successfully compiled and test suite passed on both Linux (Linux 5.7.8-arch1-1 #1 SMP PREEMPT Thu, 09 Jul 2020 16:34:01 +0000 x86_64 GNU/Linux) and Mac (Darwin 19.5.0 Darwin Kernel Version 19.5.0: Tue May 26 20:41:44 PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64). Windows testing pending as I do not have access to a working Windows machine. 

---
Result of running test suite on Linux:
```
$ npm test

> keytar@6.0.1 test /home/robert/Dev/node-keytar
> npm run lint && npm build . && mocha --require babel-core/register spec/


> keytar@6.0.1 lint /home/robert/Dev/node-keytar
> npm run cpplint


> keytar@6.0.1 cpplint /home/robert/Dev/node-keytar
> node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc


> keytar@6.0.1 install /home/robert/Dev/node-keytar
> prebuild-install || node-gyp rebuild

make: Entering directory '/home/robert/Dev/node-keytar/build'
  CXX(target) Release/obj.target/keytar/src/async.o
  CXX(target) Release/obj.target/keytar/src/main.o
  CXX(target) Release/obj.target/keytar/src/keytar_posix.o
  SOLINK_MODULE(target) Release/obj.target/keytar.node
  COPY Release/keytar.node
make: Leaving directory '/home/robert/Dev/node-keytar/build'


  keytar
    setPassword/getPassword(service, account)
      ✓ sets and yields the password for the service and account
      ✓ yields null when the password was not found
      error handling
        setPassword
          ✓ handles when an object is provided for service
          ✓ handles when an object is provided for username
          ✓ handles when an object is provided for password
        getPassword
          ✓ handles when an object is provided for service
          ✓ handles when an object is provided for username
      Unicode support
        ✓ handles unicode strings everywhere
    deletePassword(service, account)
      ✓ yields true when the password was deleted
      ✓ yields false when the password didn't exist
      error handling
        ✓ handles when an object is provided for service
        ✓ handles when an object is provided for username
    findPassword(service)
      ✓ yields a password for the service
      ✓ yields null when no password can be found
      ✓ handles when an object is provided for service
    findCredentials(service)
      ✓ yields an array of the credentials
      ✓ returns an empty array when no credentials are found
      ✓ handles when an object is provided for service
      Unicode support
        ✓ handles unicode strings everywhere


  19 passing (150ms)
```
---
Result of running test suite on Mac:
```
$ npm test

> keytar@6.0.1 test /Users/robert.pisani/Dev/node-keytar
> npm run lint && npm build . && mocha --require babel-core/register spec/


> keytar@6.0.1 lint /Users/robert.pisani/Dev/node-keytar
> npm run cpplint


> keytar@6.0.1 cpplint /Users/robert.pisani/Dev/node-keytar
> node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc

 ✓ src/async.cc
 ✓ src/keytar_mac.cc
 ✓ src/keytar_posix.cc
 ✓ src/keytar_win.cc
 ✓ src/main.cc

> keytar@6.0.1 install /Users/robert.pisani/Dev/node-keytar
> prebuild-install || node-gyp rebuild

  CXX(target) Release/obj.target/keytar/src/async.o
  CXX(target) Release/obj.target/keytar/src/main.o
  CXX(target) Release/obj.target/keytar/src/keytar_mac.o
  SOLINK_MODULE(target) Release/keytar.node


  keytar
    setPassword/getPassword(service, account)
      ✓ sets and yields the password for the service and account (53ms)
      ✓ yields null when the password was not found
      error handling
        setPassword
          ✓ handles when an object is provided for service
          ✓ handles when an object is provided for username
          ✓ handles when an object is provided for password
        getPassword
          ✓ handles when an object is provided for service
          ✓ handles when an object is provided for username
      Unicode support
        ✓ handles unicode strings everywhere
    deletePassword(service, account)
      ✓ yields true when the password was deleted
      ✓ yields false when the password didn't exist
      error handling
        ✓ handles when an object is provided for service
        ✓ handles when an object is provided for username
    findPassword(service)
      ✓ yields a password for the service (47ms)
      ✓ yields null when no password can be found
      ✓ handles when an object is provided for service
    findCredentials(service)
      ✓ yields an array of the credentials (65ms)
      ✓ returns an empty array when no credentials are found
      ✓ handles when an object is provided for service
      Unicode support
        ✓ handles unicode strings everywhere


  19 passing (367ms)
```
---

### Release Notes

- Return service property from findCredentials method
