### PR TITLE
add rust bindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Depending on your distribution, you will need to run the following command:
 
 Each release of `keytar` includes prebuilt binaries for the versions of Node and Electron that are actively supported by these projects. Please refer to the release documentation for [Node](https://github.com/nodejs/Release) and [Electron](https://electronjs.org/docs/tutorial/support) to see what is supported currently.
 
+## Bindings from other languages
+
+- [Rust](https://crates.io/crates/keytar)
+
 ## Docs
 
 ```javascript


### PR DESCRIPTION
### Description of the Change

As discussed in #279 

### Release Notes

- Add Rust bindings to README

### Notes

This took a bit longer since a change upstream was needed before using the bindings crate from crates.io worked reliably.

Resolves #279 