### PR TITLE
Add prebuild Electron for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && npm run prebuild-electron-arm64"; fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ build_script:
   - npm run prebuild-node-ia32
   - npm run prebuild-electron
   - npm run prebuild-electron-ia32
+  - npm run prebuild-electron-arm64
   - if defined APPVEYOR_REPO_TAG_NAME (npm run upload)
 
 test: off

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron --strip",
+    "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a arm64 --strip",
     "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"


### PR DESCRIPTION
### Identify the Bug

Currently, including keytar as a dependency results in the following error on Windows arm64:

```
error C:\repos\desktop\app\node_modules\keytar: Command failed.
Exit code: 1
Command: prebuild-install || node-gyp rebuild
Arguments:
Directory: C:\repos\desktop\app\node_modules\keytar
Output:
prebuild-install WARN install No prebuilt binaries found (target=9.3.1 runtime=electron arch=arm64 libc= platform=win32)

C:\repos\desktop\app\node_modules\keytar>if not defined npm_config_node_gyp (node "C:\Program Files\nodejs\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "" rebuild )
gyp info it worked if it ends with ok
gyp info using node-gyp@5.1.0
gyp info using node@14.13.0 | win32 | arm64
gyp info find Python using Python version 3.8.5 found at "C:\Python38\python.exe"
gyp info find VS using VS2019 (16.7.30330.147) found at:
gyp info find VS "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
```

```
Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
  async.cc
  main.cc
  keytar_win.cc
  win_delay_load_hook.cc
C:\repos\desktop\app\node_modules\keytar\src\main.cc(1,10): fatal error C1083: Cannot open include file: 'napi.h': No such file or directory [C:\repos\desktop\app\node_modules\keytar\build\keytar.vcxproj]
C:\repos\desktop\app\node_modules\keytar\src\async.cc(4,10): fatal error C1083: Cannot open include file: 'napi.h': No such file or directory [C:\repos\desktop\app\node_modules\keytar\build\keytar.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:314:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
gyp ERR! System Windows_NT 10.0.19042
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\repos\desktop\app\node_modules\keytar
gyp ERR! node -v v14.13.0
```

Related issue: https://github.com/atom/node-keytar/issues/297

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

This PR adds prebuilds for Electron on arm64, which solved the issue for me when trying locally and adding Keytar through `yarn link keytar` (while trying to add support for arm64 to GitHub Desktop https://github.com/desktop/desktop/pull/9691)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

- Add prebuild Electron binaries for arm64

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->