### PR TITLE
use forked node-abi to get correct prebuild versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 os:
   - linux
   - osx
-node_js: 14
+node_js: 15
 
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ platform:
   - x64
 
 environment:
-  nodejs_version: "14"
+  nodejs_version: "15"
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ branches:
 clone_depth: 10
 
 install:
-  - ps: Install-Product node $env:nodejs_version x64
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ build_script:
   - npm run prebuild-electron-ia32
   - npm run prebuild-electron-arm64
   - if defined APPVEYOR_REPO_TAG_NAME (npm run upload)
+  - ls prebuilds/
 
 test: off
 deploy: off

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@shiftkey/node-abi": {
-      "version": "2.19.2-pre",
-      "resolved": "https://registry.npmjs.org/@shiftkey/node-abi/-/node-abi-2.19.2-pre.tgz",
-      "integrity": "sha512-+LfXo6nd2uZ8cGSJ66zL3OuddvG2oMWMc9GzpDoX2ZNMLmYpu+ReoEKXtmoKVwd6JSavDymldebCxSJh9NQ9cg==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.4.1"
-      }
-    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -2204,6 +2195,14 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-abi": {
+      "version": "github:shiftkey/node-abi#abe2c8b66c269345bd1cbf3b5f25d5714cf19dc7",
+      "from": "github:shiftkey/node-abi#abe2c8b66c269345bd1cbf3b5f25d5714cf19dc7",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
     },
     "node-addon-api": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@shiftkey/node-abi": {
+      "version": "2.19.2-pre",
+      "resolved": "https://registry.npmjs.org/@shiftkey/node-abi/-/node-abi-2.19.2-pre.tgz",
+      "integrity": "sha512-+LfXo6nd2uZ8cGSJ66zL3OuddvG2oMWMc9GzpDoX2ZNMLmYpu+ReoEKXtmoKVwd6JSavDymldebCxSJh9NQ9cg==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -2196,14 +2205,6 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
-    "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
-      "requires": {
-        "semver": "^5.4.1"
-      }
-    },
     "node-addon-api": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
@@ -2661,6 +2662,15 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
+        "node-abi": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+          "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.4.1"
+          }
+        },
         "node-gyp": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
@@ -2708,6 +2718,14 @@
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "node-abi": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+          "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+          "requires": {
+            "semver": "^5.4.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
-    "@shiftkey/node-abi": "2.19.2-pre",
+    "node-abi": "shiftkey/node-abi#abe2c8b66c269345bd1cbf3b5f25d5714cf19dc7",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^7.0.0",
     "prebuild": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
-    "node-abi": "shiftkey/node-abi#abe2c8b66c269345bd1cbf3b5f25d5714cf19dc7",
+    "node-abi": "github:shiftkey/node-abi#abe2c8b66c269345bd1cbf3b5f25d5714cf19dc7",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^7.0.0",
     "prebuild": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "npm run cpplint",
     "cpplint": "node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc",
     "test": "npm run lint && npm build . && mocha --require babel-core/register spec/",
-    "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 --strip",
+    "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron --strip",
     "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a arm64 --strip",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
-    "node-abi": "^2.17.0",
+    "@shiftkey/node-abi": "2.19.2-pre",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^7.0.0",
     "prebuild": "^10.0.0"


### PR DESCRIPTION
Resolves #317 

This PR adds a temporary fork of `node-abi` that contains the fix for #317, which is pending review at https://github.com/lgeiger/node-abi/pull/95

Diff: https://github.com/lgeiger/node-abi/compare/master...shiftkey:fix-abi-registry-updater

TODO: 

 - [x] add Node 15 support
 - [ ] confirm all platforms building as expected