### PR TITLE
Update binding.gyp to fix "napi.h not found" error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       'msvs_settings': {
         'VCCLCompilerTool': { 'ExceptionHandling': 1 },
       },
-      'include_dirs' : [ "<!@(node -p \"require('node-addon-api').include\")" ],
+      'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
       'sources': [
         'src/async.cc',
         'src/main.cc',


### PR DESCRIPTION
Fixes https://github.com/atom/node-keytar/issues/297

For some reason, the @ in `<!@(node -p \"require('node-addon-api').include\")` causes `node-gyp rebuild` to fail with:

```
Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
  async.cc
  main.cc
  keytar_win.cc
  win_delay_load_hook.cc
C:\repos\desktop\app\node_modules\keytar\src\main.cc(1,10): fatal error C1083: Cannot open include file: 'napi.h': No such file or directory [C:\repos\desktop\app\node_modules\keytar\build\keytar.vcxproj]
C:\repos\desktop\app\node_modules\keytar\src\async.cc(4,10): fatal error C1083: Cannot open include file: 'napi.h': No such file or directory [C:\repos\desktop\app\node_modules\keytar\build\keytar.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:314:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
gyp ERR! System Windows_NT 10.0.19042
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\repos\desktop\app\node_modules\keytar
gyp ERR! node -v v14.13.0
```

This PR fixes this problem by changing `include_dirs` to the value that is indicated in `node-addon-api`'s official docs: https://github.com/nodejs/node-addon-api/blob/master/doc/setup.md#installation-and-usage

While https://github.com/atom/node-keytar/pull/319 fixed arm64 builds on Windows by adding prebuilds for Electron (which works around the issue), it doesn't actually fix the scenario for native (re)compilation. This PR does. 🚀 