### PR TITLE
Add prebuilds for Electron 11 (including Apple Silicon)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
       if: ${{ matrix.os != 'macos-latest' }}
       name: Prebuild for Electron (ARM64)
 
+    - run: npm run prebuild-electron-arm64-mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      name: Prebuild for Electron MacOS (ARM64)
+
     - run: |
         docker build -t node-keytar/i386 docker/i386
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,6 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm run prebuild-electron-arm64-mac; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && npm run prebuild-electron-arm64"; fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,98 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@shiftkey/node-abi": {
-      "version": "2.19.2-pre",
-      "resolved": "https://registry.npmjs.org/@shiftkey/node-abi/-/node-abi-2.19.2-pre.tgz",
-      "integrity": "sha512-+LfXo6nd2uZ8cGSJ66zL3OuddvG2oMWMc9GzpDoX2ZNMLmYpu+ReoEKXtmoKVwd6JSavDymldebCxSJh9NQ9cg==",
-      "requires": {
-        "semver": "^5.4.1"
-      }
-    },
-    "@shiftkey/prebuild": {
-      "version": "10.0.2-pre2",
-      "resolved": "https://registry.npmjs.org/@shiftkey/prebuild/-/prebuild-10.0.2-pre2.tgz",
-      "integrity": "sha512-1PZ99NreaS3SOoXK2VHelPu8mcw/fB6z42hiidOYmfvLlFrpwMju+p1bYIkDPd6Di+7TONnW4845SRjf5zM0yQ==",
-      "dev": true,
-      "requires": {
-        "@shiftkey/node-abi": "2.19.2-pre",
-        "cmake-js": "~5.2.0",
-        "detect-libc": "^1.0.3",
-        "each-series-async": "^1.0.1",
-        "execspawn": "^1.0.1",
-        "ghreleases": "^3.0.2",
-        "github-from-package": "0.0.0",
-        "glob": "^7.1.6",
-        "minimist": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "napi-build-utils": "^1.0.1",
-        "node-gyp": "^6.0.1",
-        "node-ninja": "^1.0.1",
-        "noop-logger": "^0.1.0",
-        "npm-which": "^3.0.1",
-        "npmlog": "^4.0.1",
-        "nw-gyp": "^3.6.3",
-        "rc": "^1.0.3",
-        "run-waterfall": "^1.1.6",
-        "tar-stream": "^2.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "node-gyp": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
-          "integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "semver": "^5.7.1",
-            "tar": "^4.4.12",
-            "which": "^1.3.1"
-          }
-        }
-      }
-    },
-    "@shiftkey/prebuild-install": {
-      "version": "6.0.1-pre2",
-      "resolved": "https://registry.npmjs.org/@shiftkey/prebuild-install/-/prebuild-install-6.0.1-pre2.tgz",
-      "integrity": "sha512-wDV1DgFxi0F+kTpyGNdnDctdw3Rb9aP8RBAGFE2wXr1+pXSCJRRA+Qh5ko5dKc0LeNIBZzjEECjmtAykajv+Xw==",
-      "requires": {
-        "@shiftkey/node-abi": "2.19.2-pre",
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
-      }
-    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -2351,6 +2259,14 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "node-addon-api": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
@@ -2773,6 +2689,90 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "prebuild": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
+      "integrity": "sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==",
+      "dev": true,
+      "requires": {
+        "cmake-js": "~5.2.0",
+        "detect-libc": "^1.0.3",
+        "each-series-async": "^1.0.1",
+        "execspawn": "^1.0.1",
+        "ghreleases": "^3.0.2",
+        "github-from-package": "0.0.0",
+        "glob": "^7.1.6",
+        "minimist": "^1.1.2",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.2.0",
+        "node-gyp": "^6.0.1",
+        "node-ninja": "^1.0.1",
+        "noop-logger": "^0.1.0",
+        "npm-which": "^3.0.1",
+        "npmlog": "^4.0.1",
+        "nw-gyp": "^3.6.3",
+        "rc": "^1.0.3",
+        "run-waterfall": "^1.1.6",
+        "tar-stream": "^2.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "node-gyp": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
+          "integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
+          "dev": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.0",
+            "rimraf": "^2.6.3",
+            "semver": "^5.7.1",
+            "tar": "^4.4.12",
+            "which": "^1.3.1"
+          }
+        }
+      }
+    },
+    "prebuild-install": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
+      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron --strip",
     "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a arm64 --strip",
+    "prebuild-electron-arm64-mac": "prebuild -t 11.0.0 -r electron -a arm64 --strip",
     "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test": "npm run lint && npm rebuild && mocha --require babel-core/register spec/",
     "prebuild-node": "prebuild -t 8.9.0 -t 9.4.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron --strip",
-    "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a arm64 --strip",
-    "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron --strip",
+    "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a arm64 --strip",
+    "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"
   },
@@ -47,13 +47,13 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
-    "@shiftkey/node-abi": "2.19.2-pre",
+    "node-abi": "^2.19.3",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^7.0.0",
-    "@shiftkey/prebuild": "10.0.2-pre2"
+    "prebuild": "^10.0.1"
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",
-    "@shiftkey/prebuild-install": "6.0.1-pre2"
+    "prebuild-install": "^6.0.0"
   }
 }


### PR DESCRIPTION
Adds the prebuilds for Electron 11, [which was released yesterday](https://www.electronjs.org/releases/stable#11.0.0).

Looks like the issues with `node-abi` have been resolved in their [2.19.3 release](https://github.com/lgeiger/node-abi/releases/tag/v2.19.3). I needed to switch back to the official `node-abi` because otherwise the prebuild for Electron 11 didn't work.

Since Electron [now also supports Apple Silicon](https://www.electronjs.org/blog/apple-silicon) starting with v11, this PR also adds a separate prebuild script for that 🍎 