### PR TITLE
Switch to N-API prebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       CC: "clang"
       CXX: "clang++"
       npm_config_clang: "1"
+      # Needed until macos-11.0 hosted runners are available
+      SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk"
 
     strategy:
       matrix:
@@ -46,6 +48,15 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Install additional dependencies
 
+    # This step can be removed as soon as official Windows arm64 builds are published:
+    # https://github.com/nodejs/build/issues/2450#issuecomment-705853342
+    - run: |
+        $NodeVersion = (node --version) -replace '^.'
+        $NodeFallbackVersion = "15.2.1"
+        & .\script\download-node-lib-win-arm64.ps1 $NodeVersion $NodeFallbackVersion
+      if: ${{ matrix.os == 'windows-latest' }}
+      name: Install Windows arm64 node.lib
+
     - run: npm install
       name: Setup environment
 
@@ -66,23 +77,23 @@ jobs:
       if: ${{ matrix.os != 'ubuntu-16.04' }}
       name: Run tests (Windows/macOS)
 
-    - run: |
-        npm run prebuild-node
-        npm run prebuild-electron
+    - run: npm run prebuild-napi-x64
       name: Prebuild (x64)
 
-    - run: |
-        npm run prebuild-electron-arm64
-        npm run prebuild-electron-ia32
+    - run: npm run prebuild-napi-arm64
+      name: Prebuild (arm64)
+      if: ${{ matrix.os != 'ubuntu-16.04' }}
+
+    - run: npm run prebuild-napi-ia32
       if: ${{ matrix.os == 'windows-latest' }}
-      name: Prebuild (Windows x86 + ARM64)
+      name: Prebuild (Windows x86)
 
     - run: |
         mkdir -p prebuilds && chmod 777 prebuilds
         docker build -t node-keytar/i386 docker/i386
-        docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-electron-ia32 && rm -rf build"
+        docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-napi-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
-        docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
+        docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-napi-arm64"
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Prebuild (Linux x86 + ARM64)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,8 @@ jobs:
       name: Setup environment
 
     - run: |
-        npm run prebuild-node
-        npm run prebuild-electron
-        npm run prebuild-electron-arm64
+        npm run prebuild-napi-x64
+        npm run prebuild-napi-arm64
       name: Prebuild
 
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # https://github.com/nodejs/build/issues/2450#issuecomment-705853342
     - run: |
         $NodeVersion = (node --version) -replace '^.'
-        $NodeFallbackVersion = "15.2.1"
+        $NodeFallbackVersion = "15.8.0"
         & .\script\download-node-lib-win-arm64.ps1 $NodeVersion $NodeFallbackVersion
       if: ${{ matrix.os == 'windows-latest' }}
       name: Install Windows arm64 node.lib

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,9 @@
   'targets': [
     {
       'target_name': 'keytar',
+      'defines': [
+        "NAPI_VERSION=<(napi_build_version)",
+      ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/package.json
+++ b/package.json
@@ -35,10 +35,9 @@
     "lint": "npm run cpplint",
     "cpplint": "node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc",
     "test": "npm run lint && npm rebuild && mocha --require babel-core/register spec/",
-    "prebuild-node": "prebuild -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 --strip",
-    "prebuild-electron": "prebuild -t 10.0.0 -t 11.0.0 -t 12.0.0 -r electron --strip",
-    "prebuild-electron-arm64": "prebuild -t 10.0.0 -t 11.0.0 -t 12.0.0 -r electron -a arm64 --strip",
-    "prebuild-electron-ia32": "prebuild -t 10.0.0 -t 11.0.0  -t 12.0.0 -r electron -a ia32 --strip",
+    "prebuild-napi-x64": "prebuild -t 3 -r napi -a x64 --strip",
+    "prebuild-napi-ia32": "prebuild -t 3 -r napi -a ia32 --strip",
+    "prebuild-napi-arm64": "prebuild -t 3 -r napi -a arm64 --strip",
     "upload": "node ./script/upload.js"
   },
   "devDependencies": {
@@ -46,7 +45,6 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
-    "node-abi": "^2.19.3",
     "node-cpplint": "~0.4.0",
     "node-gyp": "^7.0.0",
     "prebuild": "^10.0.1"
@@ -54,5 +52,14 @@
   "dependencies": {
     "node-addon-api": "^3.0.0",
     "prebuild-install": "^6.0.0"
+  },
+  "binary": {
+    "napi_versions": [
+      3
+    ]
+  },
+  "config": {
+    "runtime": "napi",
+    "target": 3
   }
 }

--- a/script/download-node-lib-win-arm64.ps1
+++ b/script/download-node-lib-win-arm64.ps1
@@ -1,0 +1,36 @@
+# This script can be removed as soon as official Windows arm64 builds are published:
+# https://github.com/nodejs/build/issues/2450#issuecomment-705853342
+
+$nodeVersion = $args[0]
+$fallbackVersion = $args[1]
+
+If ($null -eq $nodeVersion -Or $null -eq $fallbackVersion) {
+  Write-Error "No NodeJS version given as argument to this file. Run it like download-nodejs-win-arm64.ps1 NODE_VERSION NODE_FALLBACK_VERSION"
+  exit 1
+}
+
+$url = "https://unofficial-builds.nodejs.org/download/release/v$nodeVersion/win-arm64/node.lib"
+$fallbackUrl = "https://unofficial-builds.nodejs.org/download/release/v$fallbackVersion/win-arm64/node.lib"
+
+# Always write to the $nodeVersion cache folder, even if we're using the fallbackVersion
+$cacheFolder = "$env:TEMP\prebuild\napi\$nodeVersion\arm64"
+
+If (!(Test-Path $cacheFolder)) {
+  New-Item -ItemType Directory -Force -Path $cacheFolder
+}
+
+$output = "$cacheFolder\node.lib"
+$start_time = Get-Date
+
+Try {
+  Invoke-WebRequest -Uri $url -OutFile $output
+  $downloadedNodeVersion = $nodeVersion
+} Catch {
+  If ($_.Exception.Response -And $_.Exception.Response.StatusCode -eq "NotFound") {
+    Write-Output "No arm64 node.lib found for Node Windows $nodeVersion, trying fallback version $fallbackVersion..."
+    Invoke-WebRequest -Uri $fallbackUrl -OutFile $output
+    $downloadedNodeVersion = $fallbackVersion
+  }
+}
+
+Write-Output "Downloaded arm64 NodeJS lib v$downloadedNodeVersion to $output in $((Get-Date).Subtract($start_time).Seconds) second(s)"


### PR DESCRIPTION
Closes #330

This PR creates N-API prebuild binaries instead of separate ones for Node and Electron. This is supported by NodeJS versions 8.11.2 and higher: https://nodejs.org/api/n-api.html#n_api_n_api_version_matrix 

## Testing this PR
Tested this on GitHub Desktop by doing `yarn remove keytar && yarn add @dennisameling/keytar-temp` (https://github.com/dennisameling/node-keytar/releases/tag/v7.4.99-beta) - it works as expected 🚀

```
C:\repos\desktop\app>yarn add @dennisameling/keytar-temp
yarn add v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 3 new dependencies.
info Direct dependencies
└─ @dennisameling/keytar-temp@7.1.1-beta
info All dependencies
├─ @dennisameling/keytar-temp@7.1.1-beta
├─ mkdirp-classic@0.5.3
└─ node-addon-api@3.0.2
Done in 18.29s.
```

Output of `prebuild-install --verbose`  also shows that `prebuild` is correctly downloading the N-API prebuild binaries:

```
C:\repos\node-keytar>prebuild-install --verbose
prebuild-install info begin Prebuild-install version 6.0.0
prebuild-install info looking for cached prebuild @ C:\Users\denni\AppData\Roaming\npm-cache\_prebuilds\14731b-keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz
prebuild-install http request GET https://github.com/dennisameling/node-keytar/releases/download/v7.1.1-beta/keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz
prebuild-install http 200 https://github.com/dennisameling/node-keytar/releases/download/v7.1.1-beta/keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz
prebuild-install info downloading to @ C:\Users\denni\AppData\Roaming\npm-cache\_prebuilds\14731b-keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz.21480-fe4ffc5c96c92.tmp
prebuild-install info renaming to @ C:\Users\denni\AppData\Roaming\npm-cache\_prebuilds\14731b-keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz
prebuild-install info unpacking @ C:\Users\denni\AppData\Roaming\npm-cache\_prebuilds\14731b-keytar-temp-v7.1.1-beta-napi-v3-win32-arm64.tar.gz
prebuild-install info unpack resolved to C:\repos\node-keytar\build\Release\keytar.node
prebuild-install info install Successfully installed prebuilt binary!
```