### PR TITLE
add new command specifically to support rebuilding module

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,9 @@ jobs:
 
     # Setup dependencies (and build native modules from source)
     - name: Install dependencies
-      run: npm install
+      run: |
+        npm install
+        npm run build
 
     # Run code analysis
     - name: Perform CodeQL Analysis

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "types": "./keytar.d.ts",
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
+    "build": "node-gyp rebuild",
     "lint": "npm run cpplint",
     "cpplint": "node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc",
     "test": "npm run lint && npm rebuild && mocha --require babel-core/register spec/",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "types": "./keytar.d.ts",
   "scripts": {
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "prebuild-install || npm run build",
     "build": "node-gyp rebuild",
     "lint": "npm run cpplint",
     "cpplint": "node-cpplint --filters legal-copyright,build-include,build-namespaces src/*.cc",


### PR DESCRIPTION
We don't test codescanning on PRs, and I think since we restored the right prebuild versions in #326 and publishing a new release we're not building the native module from source:

 - [x] confirm codescanning failure on branch
 - [x] update config to ensure `node-gyp rebuild` runs
 - [x] codescanning CI passes