### PR TITLE
Remove Apple Silicon Electron prebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,6 @@ jobs:
       if: ${{ matrix.os != 'macos-latest' }}
       name: Prebuild for Electron (ARM64)
 
-    - run: npm run prebuild-electron-arm64-mac
-      if: ${{ matrix.os == 'macos-latest' }}
-      name: Prebuild for Electron MacOS (ARM64)
-
     - run: |
         docker build -t node-keytar/i386 docker/i386
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,5 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm run prebuild-electron-arm64-mac; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && npm run prebuild-electron-arm64"; fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "prebuild-node-ia32": "prebuild -t 8.9.0 -t 9.4.0 -a ia32 --strip",
     "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron --strip",
     "prebuild-electron-arm64": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a arm64 --strip",
-    "prebuild-electron-arm64-mac": "prebuild -t 11.0.0 -r electron -a arm64 --strip",
     "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js",
     "postpublish": "git push --follow-tags"


### PR DESCRIPTION
Fixes https://github.com/atom/node-keytar/issues/339

The generated rebuild for arm64 has the wrong architecture. `x86_64` and `ia32` (converted into `i386` for Xcode) work as expected, but when specifying `arm64` node-gyp doesn't seem to pass it on to the compiler and it just falls back to `x86_64` without any warning or error. See below:

Prebuild does its job correctly: `prebuild verb architecture arm64` but then further down in the log `c++ -bundle -undefined dynamic_lookup -Wl,-no_pie -Wl,-search_paths_first -mmacosx-version-min=10.7 -arch x86_64` (note the x86_64).

My apologies for not catching this issue; by (temporarily?) removing the prebuild this should fix the issue on affected devices.

Might be related to https://github.com/nodejs/gyp-next/pull/78#issuecomment-736878636

```
prebuild -t 11.0.2 -r electron -a arm64 --strip --debug --verbose
prebuild info begin Prebuild version 10.0.1
prebuild info build Preparing to prebuild keytar@7.2.0 for electron 11.0.2 on darwin-arm64 using node-gyp
prebuild verb starting build process node-gyp 
prebuild verb execute node-gyp with `node index.js rebuild --target=11.0.2 --target_arch=arm64 --runtime=electron --dist-url=https://atom.io/download/electron --debug` 
prebuild verb command rebuild []
prebuild verb ok 
prebuild verb command clean []
prebuild verb clean removing "build" directory
prebuild verb ok 
prebuild verb command configure []
prebuild verb download using dist-url https://atom.io/download/electron
prebuild verb find Python Python is not set from command line or npm configuration
prebuild verb find Python Python is not set from environment variable PYTHON
prebuild verb find Python checking if "python3" can be used
prebuild verb find Python - executing "python3" to get executable path
prebuild verb find Python - executable path is "/Applications/Xcode.app/Contents/Developer/usr/bin/python3"
prebuild verb find Python - executing "/Applications/Xcode.app/Contents/Developer/usr/bin/python3" to get version
prebuild verb find Python - version is "3.8.2"
prebuild info find Python using Python version 3.8.2 found at "/Applications/Xcode.app/Contents/Developer/usr/bin/python3"
prebuild verb get node dir compiling against --target node version: 11.0.2
prebuild verb command install [ '11.0.2' ]
prebuild verb download using dist-url https://atom.io/download/electron
prebuild verb install input version string "11.0.2"
prebuild verb install installing version: 11.0.2
prebuild verb install --ensure was passed, so won't reinstall if already installed
prebuild verb install version is already installed, need to check "installVersion"
prebuild verb got "installVersion" 9
prebuild verb needs "installVersion" 9
prebuild verb install version is good
prebuild verb get node dir target node version installed: 11.0.2
prebuild verb build dir attempting to create "build" dir: /Users/Dennis/GitHub/node-keytar/build
prebuild verb build dir "build" dir needed to be created? /Users/Dennis/GitHub/node-keytar/build
prebuild verb build/config.gypi creating config file
prebuild verb build/config.gypi writing out config file: /Users/Dennis/GitHub/node-keytar/build/config.gypi
prebuild verb config.gypi checking for gypi file: /Users/Dennis/GitHub/node-keytar/config.gypi
prebuild verb common.gypi checking for gypi file: /Users/Dennis/GitHub/node-keytar/common.gypi
prebuild verb gyp gyp format was not specified; forcing "make"
prebuild info spawn /Applications/Xcode.app/Contents/Developer/usr/bin/python3
prebuild info spawn args [
prebuild info spawn args   '/usr/local/lib/node_modules/prebuild/node_modules/node-gyp/gyp/gyp_main.py',
prebuild info spawn args   'binding.gyp',
prebuild info spawn args   '-f',
prebuild info spawn args   'make',
prebuild info spawn args   '-I',
prebuild info spawn args   '/Users/Dennis/GitHub/node-keytar/build/config.gypi',
prebuild info spawn args   '-I',
prebuild info spawn args   '/usr/local/lib/node_modules/prebuild/node_modules/node-gyp/addon.gypi',
prebuild info spawn args   '-I',
prebuild info spawn args   '/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/include/node/common.gypi',
prebuild info spawn args   '-Dlibrary=shared_library',
prebuild info spawn args   '-Dvisibility=default',
prebuild info spawn args   '-Dnode_root_dir=/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2',
prebuild info spawn args   '-Dnode_gyp_dir=/usr/local/lib/node_modules/prebuild/node_modules/node-gyp',
prebuild info spawn args   '-Dnode_lib_file=/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/<(target_arch)/node.lib',
prebuild info spawn args   '-Dmodule_root_dir=/Users/Dennis/GitHub/node-keytar',
prebuild info spawn args   '-Dnode_engine=v8',
prebuild info spawn args   '--depth=.',
prebuild info spawn args   '--no-parallel',
prebuild info spawn args   '--generator-output',
prebuild info spawn args   'build',
prebuild info spawn args   '-Goutput_dir=.'
prebuild info spawn args ]
prebuild verb ok 
prebuild verb command build []
prebuild verb build type Debug
prebuild verb architecture arm64
prebuild verb node dev dir /var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2
prebuild verb `which` succeeded for `make` /usr/bin/make
prebuild info spawn make
prebuild info spawn args [ 'V=1', 'BUILDTYPE=Debug', '-C', 'build' ]
  c++ '-DNODE_GYP_MODULE_NAME=keytar' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DBUILDING_NODE_EXTENSION' '-DDEBUG' '-D_DEBUG' '-DV8_ENABLE_CHECKS' -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/include/node -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/src -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/config -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/openssl/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/uv/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/zlib -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/v8/include -I../node_modules/node-addon-api  -O0 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=gnu++1y -stdlib=libc++ -fno-rtti -fno-strict-aliasing -MMD -MF ./Debug/.deps/Debug/obj.target/keytar/src/async.o.d.raw   -c -o Debug/obj.target/keytar/src/async.o ../src/async.cc
  c++ '-DNODE_GYP_MODULE_NAME=keytar' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DBUILDING_NODE_EXTENSION' '-DDEBUG' '-D_DEBUG' '-DV8_ENABLE_CHECKS' -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/include/node -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/src -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/config -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/openssl/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/uv/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/zlib -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/v8/include -I../node_modules/node-addon-api  -O0 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=gnu++1y -stdlib=libc++ -fno-rtti -fno-strict-aliasing -MMD -MF ./Debug/.deps/Debug/obj.target/keytar/src/main.o.d.raw   -c -o Debug/obj.target/keytar/src/main.o ../src/main.cc
  c++ '-DNODE_GYP_MODULE_NAME=keytar' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DBUILDING_NODE_EXTENSION' '-DDEBUG' '-D_DEBUG' '-DV8_ENABLE_CHECKS' -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/include/node -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/src -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/config -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/openssl/openssl/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/uv/include -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/zlib -I/var/folders/v0/2dzlz0tn2r555xvm0zw9_p_40000gq/T/prebuild/electron/11.0.2/deps/v8/include -I../node_modules/node-addon-api  -O0 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=gnu++1y -stdlib=libc++ -fno-rtti -fno-strict-aliasing -MMD -MF ./Debug/.deps/Debug/obj.target/keytar/src/keytar_mac.o.d.raw   -c -o Debug/obj.target/keytar/src/keytar_mac.o ../src/keytar_mac.cc
  c++ -bundle -undefined dynamic_lookup -Wl,-no_pie -Wl,-search_paths_first -mmacosx-version-min=10.7 -arch x86_64 -L./Debug -stdlib=libc++  -o Debug/keytar.node Debug/obj.target/keytar/src/async.o Debug/obj.target/keytar/src/main.o Debug/obj.target/keytar/src/keytar_mac.o -framework AppKit
prebuild verb ok 
prebuild verb completed building node-gyp 
prebuild info build Stripping debug information from build/Debug/keytar.node
prebuild info build Packing build/Debug/keytar.node into prebuilds/keytar-v7.2.0-electron-v85-darwin-arm64.tar.gz
prebuild info build Prebuild written to prebuilds/keytar-v7.2.0-electron-v85-darwin-arm64.tar.gz
```

