### PR TITLE
Remove Linux Electron arm64 prebuild (temporary)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && npm run prebuild-electron-arm64"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"; fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi


### PR DESCRIPTION
Might be used as a temporary fix for https://github.com/atom/node-keytar/issues/347 until I have resolved the issues with Travis. This repo is still using travis-ci.org which makes it very impractical to be testing my fixes, as it takes 1+ hour to kick off the builds. I wanted to test in my own fork but somehow have a negative credit balance on travis-ci.com despite having ran 0 tests in the last 2 months 😅

If #347 is time-critical then you could merge this PR for the time being, otherwise I expect to have #349 sorted out within the coming day or two, as soon as Travis support gets back to me.
