### PR TITLE
Properly cross-compile for Linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,9 @@ jobs:
       name: Prebuild (Windows x86 + ARM64)
 
     - run: |
+        mkdir -p prebuilds && chmod 777 prebuilds
         docker build -t node-keytar/i386 docker/i386
-        docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
+        docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
       if: ${{ matrix.os == 'ubuntu-16.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         docker build -t node-keytar/i386 docker/i386
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
-        docker run --rm -v ${PWD}:/project node-keytar/arm-64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
+        docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Prebuild (Linux x86 + ARM64)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,21 +70,20 @@ jobs:
         npm run prebuild-electron
       name: Prebuild (x64)
 
-    - run: npm run prebuild-electron-arm64
-      if: ${{ matrix.os != 'macos-latest' }}
-      name: Prebuild for Electron (ARM64)
+    - run: |
+        npm run prebuild-electron-arm64
+        npm run prebuild-node-ia32
+        npm run prebuild-electron-ia32
+      if: ${{ matrix.os == 'windows-latest' }}
+      name: Prebuild (Windows x86 + ARM64)
 
     - run: |
         docker build -t node-keytar/i386 docker/i386
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
+        docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
+        docker run --rm -v ${PWD}:/project node-keytar/arm-64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
       if: ${{ matrix.os == 'ubuntu-16.04' }}
-      name: Prebuild (x86)
-
-    - run: |
-        npm run prebuild-node-ia32
-        npm run prebuild-electron-ia32
-      if: ${{ matrix.os == 'windows-latest' }}
-      name: Prebuild (x86)
+      name: Prebuild (Linux x86 + ARM64)
 
     - run: |
         ls prebuilds/

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,11 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
   - npm run prebuild-node
   - npm run prebuild-electron
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t node-keytar/i386 docker/i386 && docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && npm run prebuild-electron-arm64"; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker build -t node-keytar/i386 docker/i386
+      docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
+      docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
+      docker run --rm -v ${PWD}:/project node-keytar/arm-64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
+    fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ script:
       docker build -t node-keytar/i386 docker/i386
       docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
       docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
-      docker run --rm -v ${PWD}:/project node-keytar/arm-64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
+      docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
     fi
   - if [[ -n "$TRAVIS_TAG" ]]; then npm run upload; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,9 @@ script:
   - npm run prebuild-electron
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      mkdir -p prebuilds && chmod 777 prebuilds
       docker build -t node-keytar/i386 docker/i386
-      docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32"
+      docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-node-ia32 && npm run prebuild-electron-ia32 && rm -rf build"
       docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
       docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
     fi

--- a/docker/arm64-cross-compile/Dockerfile
+++ b/docker/arm64-cross-compile/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:buster
+
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  crossbuild-essential-arm64 \
+  python \
+  git \
+  pkg-config \
+  fakeroot \
+  rpm \
+  ca-certificates \
+  libx11-dev:arm64 \
+  libx11-xcb-dev:arm64 \
+  libxkbfile-dev:arm64 \
+  libsecret-1-dev:arm64 \
+  curl
+
+ENV AS=/usr/bin/aarch64-linux-gnu-as \
+  STRIP=/usr/bin/aarch64-linux-gnu-strip \
+  AR=/usr/bin/aarch64-linux-gnu-ar \
+  CC=/usr/bin/aarch64-linux-gnu-gcc \
+  CPP=/usr/bin/aarch64-linux-gnu-cpp \
+  CXX=/usr/bin/aarch64-linux-gnu-g++ \
+  LD=/usr/bin/aarch64-linux-gnu-ld \
+  FC=/usr/bin/aarch64-linux-gnu-gfortran \
+  PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+RUN apt-get install -y nodejs


### PR DESCRIPTION
### Identify the Bug

See https://github.com/atom/node-keytar/issues/347

Fixes #347, successor of/alternative to https://github.com/atom/node-keytar/pull/349

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

After merging this PR, arm64 Linux Electron prebuilds will be created through cross-compilation on a x64 Ubuntu host. This eliminates the need for a native arm64 host as suggested in https://github.com/atom/node-keytar/pull/349.

Can confirm the generated file now has the proper architecture (tested on Ubuntu 20.04 locally):

```
$ file build/Release/keytar.node
build/Release/keytar.node: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=b8fb19367c28bccca9ce730d646fb9edb80f0048, stripped
```

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

None yet - the only downside of cross-compilation is that you won't be able to run automated tests for arm64 on a x64 host natively. The alternative is running tests in a QEMU-emulated arm64 Docker container on a x64 host, or leveraging Travis' [native arm64 runners](https://docs.travis-ci.com/user/multi-cpu-architectures/#multi-cpu-availaibility) like [`lovell/sharp` is doing](https://github.com/lovell/sharp/blob/master/.travis.yml). But the maintainers would need to request OSS credits for travis-ci.com, as .org is shutting down soon. Details in https://github.com/atom/node-keytar/issues/351

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Repair arm64 Linux Electron prebuilds

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->