### PR TITLE
bump all usages of python to at least 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version: [15.x]
-        os: [ubuntu-16.04, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             friendlyName: Ubuntu
           - os: windows-latest
             friendlyName: Windows
@@ -44,7 +44,7 @@ jobs:
                              dbus-x11 \
                              python-gnomekeyring \
                              python3
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Install additional dependencies
 
     - name: Setup environment
@@ -62,11 +62,11 @@ jobs:
         echo "Create a test key using script..."
         python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
         npm test
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Run tests (Linux)
 
     - run: npm test
-      if: ${{ matrix.os != 'ubuntu-16.04' }}
+      if: ${{ matrix.os != 'ubuntu-18.04' }}
       name: Run tests (Windows/macOS)
 
     - run: |
@@ -86,7 +86,7 @@ jobs:
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-electron-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Prebuild (Linux x86 + ARM64)
 
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-gnomekeyring \
+                             python3-keyring \
                              python3
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Install additional dependencies
@@ -60,7 +60,7 @@ jobs:
         eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
         eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
         echo "Create a test key using script..."
-        python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
+        python -c "import keyring;keyring.set_password('login', '');"
         npm test
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Run tests (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,10 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Install additional dependencies
 
-    - run: npm install
-      name: Setup environment
+    - name: Setup environment
+      run: |
+        npm install
+        npm run build
 
     - run: |
         echo "Initialize dbus..."
@@ -106,8 +108,10 @@ jobs:
       run: |
         apk add g++ make python3 libsecret-dev
 
-    - run: npm install
-      name: Setup environment
+    - name: Setup environment
+      run: |
+        npm install
+        npm run build
 
     - run: |
         npm run prebuild-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-gnomekeyring
+                             python-gnomekeyring \
+                             python3
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Install additional dependencies
 
@@ -103,7 +104,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install additional dependencies
       run: |
-        apk add g++ make python2 libsecret-dev
+        apk add g++ make python3 libsecret-dev
 
     - run: npm install
       name: Setup environment
@@ -139,7 +140,7 @@ jobs:
         node-version: 15.x
         registry-url: 'https://registry.npmjs.org'
 
-    - run: sudo apt-get install libsecret-1-dev
+    - run: sudo apt-get install libsecret-1-dev python3
       name: Install additional dependencies
 
     - run: npm install


### PR DESCRIPTION
Found this error while trying to ship a new release:

```
prebuild-install WARN install No prebuilt binaries found (target=15.13.0 runtime=node arch=x64 libc= platform=linux)

> keytar@8.0.0 build
> node-gyp rebuild

gyp info it worked if it ends with ok
gyp info using node-gyp@8.0.0
gyp info using node@15.13.0 | linux | x64
gyp ERR! find Python 
gyp ERR! find Python Python is not set from command line or npm configuration
gyp ERR! find Python Python is not set from environment variable PYTHON
gyp ERR! find Python checking if "python3" can be used
gyp ERR! find Python - executable path is "/usr/bin/python3"
gyp ERR! find Python - version is "3.5.2"
gyp ERR! find Python - version is 3.5.2 - should be >=3.6.0
gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
gyp ERR! find Python checking if "python" can be used
gyp ERR! find Python - executable path is "/usr/bin/python"
gyp ERR! find Python - version is "2.7.12"
gyp ERR! find Python - version is 2.7.12 - should be >=3.6.0
gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
gyp ERR! find Python 
gyp ERR! find Python **********************************************************
gyp ERR! find Python You need to install the latest version of Python.
gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
gyp ERR! find Python you can try one of the following options:
gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
gyp ERR! find Python   (accepted by both node-gyp and npm)
gyp ERR! find Python - Set the environment variable PYTHON
gyp ERR! find Python - Set the npm configuration variable python:
gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
gyp ERR! find Python For more information consult the documentation at:
gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
gyp ERR! find Python **********************************************************
gyp ERR! find Python 
gyp ERR! configure error 
gyp ERR! stack Error: Could not find any Python installation to use
gyp ERR! stack     at PythonFinder.fail (/home/runner/work/node-keytar/node-keytar/node_modules/node-gyp/lib/find-python.js:315:47)
gyp ERR! stack     at PythonFinder.runChecks (/home/runner/work/node-keytar/node-keytar/node_modules/node-gyp/lib/find-python.js:144:21)
gyp ERR! stack     at PythonFinder.<anonymous> (/home/runner/work/node-keytar/node-keytar/node_modules/node-gyp/lib/find-python.js:251:16)
gyp ERR! stack     at PythonFinder.execFileCallback (/home/runner/work/node-keytar/node-keytar/node_modules/node-gyp/lib/find-python.js:282:7)
gyp ERR! stack     at ChildProcess.exithandler (node:child_process:317:7)
gyp ERR! stack     at ChildProcess.emit (node:events:369:20)
gyp ERR! stack     at maybeClose (node:internal/child_process:1067:16)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5)
```

I think this was missed on the PR or `master` as the `prebuild-install` step will skip building the native module, which I have to workaround currently for CodeQL analysis so I might need to re-add that to catch this...