### PR TITLE
Add Electron 12+ macOS arm64 prebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       CC: "clang"
       CXX: "clang++"
       npm_config_clang: "1"
+      # Needed for macOS arm64 until hosted macos-11.0 runners become available
+      # https://github.com/actions/virtual-environments/issues/2486
+      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 
     strategy:
       matrix:
@@ -85,6 +88,17 @@ jobs:
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-electron-arm64"
       if: ${{ matrix.os == 'ubuntu-16.04' }}
       name: Prebuild (Linux x86 + ARM64)
+
+    # Due to issues in the past, we check if the generated file _actually_ was built for arm64.
+    # Example output: build/Release/keytar.node: Mach-O 64-bit bundle arm64
+    - run: |
+        npm run prebuild-electron-arm64-mac
+        if [[ "$(file build/Release/keytar.node)" != *"64-bit bundle arm64" ]]; then
+          echo "Generated arm64 build doesn't seem to have the proper architecture. Exiting."
+          exit 1
+        fi
+      if: ${{ matrix.os == 'macos-latest' }}
+      name: Prebuild (macOS arm64)
 
     - run: |
         ls prebuilds/

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prebuild-node": "prebuild -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 --strip",
     "prebuild-electron": "prebuild -t 10.0.0 -t 11.0.0 -t 12.0.0 -r electron --strip",
     "prebuild-electron-arm64": "prebuild -t 10.0.0 -t 11.0.0 -t 12.0.0 -r electron -a arm64 --strip",
+    "prebuild-electron-arm64-mac": "prebuild -t 12.0.0 -r electron -a arm64 --strip",
     "prebuild-electron-ia32": "prebuild -t 10.0.0 -t 11.0.0  -t 12.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js"
   },


### PR DESCRIPTION
Closes https://github.com/atom/node-keytar/issues/346

Adds prebuilds for Electron 12+ on macOS.