### PR TITLE
run codeql workflows on pull_request only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,6 @@
 name: "Code Scanning"
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 0 * * 0'
+on: pull_request
 
 jobs:
   CodeQL:


### PR DESCRIPTION
Addresses this warning with Dependabot update:

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.