### PR TITLE
change xcode_settings in binding.gyp for universal macOs build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,18 @@
       ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+       'xcode_settings': {
+        'OTHER_CFLAGS': [
+          '-arch x86_64',
+          '-arch arm64'
+        ],
+        'OTHER_LDFLAGS': [
+          '-Wl, -bind_at_load',
+          '-framework CoreFoundation -framework CoreServices',
+          '-arch x86_64',
+          '-arch arm64'
+        ],
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
         'MACOSX_DEPLOYMENT_TARGET': '10.7',
       },


### PR DESCRIPTION
🍎  
- makes node.keytar work on arm64 and x86 architecture
