### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python3-venv \
                              python3-dev
       if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Install additional dependencies
@@ -63,10 +62,10 @@ jobs:
       name: Build native module from source
 
     - run: |
-        python3 -m venv venv
-        source venv/bin/activate
+        echo "Install keyring..."
         pip3 install --upgrade pip
         pip3 install keyring
+        echo "Prepare D-Bus session..."
         eval $(dbus-launch --sh-syntax);
         eval $(echo 'somecredstorepass' | gnome-keyring-daemon --unlock)
         echo "Create a test key using script..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     name: ${{ matrix.friendlyName }}
     env:
-      DISPLAY: ":99.0"
       CC: "clang"
       CXX: "clang++"
       npm_config_clang: "1"
@@ -38,8 +37,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
-        sudo apt-get install xvfb \
-                             gnome-keyring \
+        sudo apt-get install gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
                              python3-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version: [15.x]
-        os: [ubuntu-16.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             friendlyName: Ubuntu
           - os: windows-latest
             friendlyName: Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-gnomekeyring
+                             python-keyring
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Install additional dependencies
 
@@ -69,7 +69,7 @@ jobs:
         eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
         eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
         echo "Create a test key using script..."
-        python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
+        python -c "import keyring;keyring.set_password('system', 'login', '');"
         npm test
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Run tests (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version: [15.x]
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             friendlyName: Ubuntu
           - os: windows-latest
             friendlyName: Windows
@@ -42,8 +42,9 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-keyring
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+                             python3-venv \
+                             python3-dev
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Install additional dependencies
 
     # This step can be removed as soon as official Windows arm64 builds are published:
@@ -62,20 +63,20 @@ jobs:
       name: Build native module from source
 
     - run: |
-        echo "Initialize dbus..."
-        export NO_AT_BRIDGE=1;
+        python3 -m venv venv
+        source venv/bin/activate
+        pip3 install --upgrade pip
+        pip3 install keyring
         eval $(dbus-launch --sh-syntax);
-        echo "Unlocking the keyring..."
-        eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
-        eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
+        eval $(echo 'somecredstorepass' | gnome-keyring-daemon --unlock)
         echo "Create a test key using script..."
-        python -c "import keyring;keyring.set_password('system', 'login', '');"
+        python -c "import keyring;keyring.set_password('system', 'login', 'pwd');"
         npm test
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Run tests (Linux)
 
     - run: npm test
-      if: ${{ matrix.os != 'ubuntu-18.04' }}
+      if: ${{ matrix.os != 'ubuntu-20.04' }}
       name: Run tests (Windows/macOS)
 
     - run: npm run prebuild-napi-x64
@@ -83,7 +84,7 @@ jobs:
 
     - run: npm run prebuild-napi-arm64
       name: Prebuild (arm64)
-      if: ${{ matrix.os != 'ubuntu-18.04' }}
+      if: ${{ matrix.os != 'ubuntu-20.04' }}
 
     - run: npm run prebuild-napi-ia32
       if: ${{ matrix.os == 'windows-latest' }}
@@ -95,7 +96,7 @@ jobs:
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-napi-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-napi-arm64"
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Prebuild (Linux x86 + ARM64)
 
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
                              libsecret-1-dev \
                              dbus-x11 \
                              python-gnomekeyring
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Install additional dependencies
 
     # This step can be removed as soon as official Windows arm64 builds are published:
@@ -71,11 +71,11 @@ jobs:
         echo "Create a test key using script..."
         python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
         npm test
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Run tests (Linux)
 
     - run: npm test
-      if: ${{ matrix.os != 'ubuntu-16.04' }}
+      if: ${{ matrix.os != 'ubuntu-20.04' }}
       name: Run tests (Windows/macOS)
 
     - run: npm run prebuild-napi-x64
@@ -83,7 +83,7 @@ jobs:
 
     - run: npm run prebuild-napi-arm64
       name: Prebuild (arm64)
-      if: ${{ matrix.os != 'ubuntu-16.04' }}
+      if: ${{ matrix.os != 'ubuntu-20.04' }}
 
     - run: npm run prebuild-napi-ia32
       if: ${{ matrix.os == 'windows-latest' }}
@@ -95,7 +95,7 @@ jobs:
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-napi-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-napi-arm64"
-      if: ${{ matrix.os == 'ubuntu-16.04' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Prebuild (Linux x86 + ARM64)
 
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     - run: |
         echo "Initialize dbus..."
-        eval $(dbus-launch -- sh);
+        eval $(dbus-run-session -- sh);
         echo "Unlocking the keyring..."
         eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --unlock)
         eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         eval $(dbus-launch -- sh);
         echo "Unlocking the keyring..."
         eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --unlock)
+        eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
         echo "Create a test key using script..."
         python -c "import keyring;keyring.set_password('system', 'login', '');"
         npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       CC: "clang"
       CXX: "clang++"
       npm_config_clang: "1"
-      # Needed until macos-11.0 hosted runners are available
-      SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk"
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-gnomekeyring
+                             python-keyring
       if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Install additional dependencies
 
@@ -69,7 +69,7 @@ jobs:
         eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
         eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
         echo "Create a test key using script..."
-        python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
+        python -c "import keyring;keyring.set_password('system', 'login', '');"
         npm test
       if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: Run tests (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version: [15.x]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             friendlyName: Ubuntu
           - os: windows-latest
             friendlyName: Windows
@@ -42,8 +42,8 @@ jobs:
                              gnome-keyring \
                              libsecret-1-dev \
                              dbus-x11 \
-                             python-keyring
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+                             python-gnomekeyring
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Install additional dependencies
 
     # This step can be removed as soon as official Windows arm64 builds are published:
@@ -63,18 +63,19 @@ jobs:
 
     - run: |
         echo "Initialize dbus..."
-        eval $(dbus-run-session -- sh);
+        export NO_AT_BRIDGE=1;
+        eval $(dbus-launch --sh-syntax);
         echo "Unlocking the keyring..."
-        eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --unlock)
+        eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
         eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
         echo "Create a test key using script..."
-        python -c "import keyring;keyring.set_password('system', 'login', '');"
+        python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
         npm test
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Run tests (Linux)
 
     - run: npm test
-      if: ${{ matrix.os != 'ubuntu-20.04' }}
+      if: ${{ matrix.os != 'ubuntu-18.04' }}
       name: Run tests (Windows/macOS)
 
     - run: npm run prebuild-napi-x64
@@ -82,7 +83,7 @@ jobs:
 
     - run: npm run prebuild-napi-arm64
       name: Prebuild (arm64)
-      if: ${{ matrix.os != 'ubuntu-20.04' }}
+      if: ${{ matrix.os != 'ubuntu-18.04' }}
 
     - run: npm run prebuild-napi-ia32
       if: ${{ matrix.os == 'windows-latest' }}
@@ -94,7 +95,7 @@ jobs:
         docker run --rm -v ${PWD}:/project node-keytar/i386 /bin/bash -c "cd /project && npm run prebuild-napi-ia32 && rm -rf build"
         docker build -t node-keytar/arm64-cross-compile docker/arm64-cross-compile
         docker run --rm -v ${PWD}:/project node-keytar/arm64-cross-compile /bin/bash -c "cd /project && npm run prebuild-napi-arm64"
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
       name: Prebuild (Linux x86 + ARM64)
 
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,9 @@ jobs:
 
     - run: |
         echo "Initialize dbus..."
-        export NO_AT_BRIDGE=1;
-        eval $(dbus-launch --sh-syntax);
+        eval $(dbus-launch -- sh);
         echo "Unlocking the keyring..."
-        eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login)
-        eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start)
+        eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --unlock)
         echo "Create a test key using script..."
         python -c "import keyring;keyring.set_password('system', 'login', '');"
         npm test


### PR DESCRIPTION
- macOS: We had set an `SDKROOT` env variable needed until there were macOS 11 runners. This is not needed anymore 🤞 
- Linux: We were using Ubuntu 16.04 runners, we need to bump those to 20.04.