### PR TITLE
Release v7.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keytar",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "typings": "keytar.d.ts",
   "name": "keytar",
   "description": "Bindings to native Mac/Linux/Windows password APIs",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Infrastructure

- Fix CI builds from latest macOS runners - #442
- Fix CI builds for Linux, by bumping to Ubuntu 20.04 runners - #442 

### Fixed

 -  Guard against `NULL` filter finding credentials on Windows - #426, thanks @sbatten!

### `dependencies` updates

 - Bump `prebuild-install` from `6.0.1` to `7.0.1`
 - Bump `node-addon-api` from `3.1.0` to `4.3.0`
 - Bump `lodash` from `4.17.19` to `4.17.21`

### `devDependencies` updates

 - Bump `node-gyp` from `7.1.2` to `8.4.1`
 - Bump `chai` from `4.3.4` to `4.3.6` 
 - Bump `mocha` from `8.3.2` to `9.2.0` 
