### PR TITLE
Add cf and qspectre flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,18 @@
         'MACOSX_DEPLOYMENT_TARGET': '10.7',
       },
       'msvs_settings': {
-        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+        'VCCLCompilerTool': {
+          'ExceptionHandling': 1,
+          'AdditionalOptions': [
+            '/Qspectre',
+            '/guard:cf'
+          ]
+        },
+        'VCLinkerTool': {
+          'AdditionalOptions': [
+            '/guard:cf'
+          ]
+        }
       },
       'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
       'sources': [


### PR DESCRIPTION
These flags came up from running [binskim](https://github.com/Microsoft/binskim) on the VS Code repo and are best practice to include when building for Windows.

Feel free to reach out on Slack/Teams to chat more about this if you'd like.

cc @sbatten @deepak1556