### PR TITLE
Ensure secret exists when tyring to read as text

### DIFF
--- a/src/keytar_posix.cc
+++ b/src/keytar_posix.cc
@@ -161,7 +161,16 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
       reinterpret_cast<char*>(g_hash_table_lookup(itemAttrs, "account")));
 
     SecretValue* secret = secret_item_get_secret(item);
-    char* password = strdup(secret_value_get_text(secret));
+    if (secret == NULL) {
+      // keystore is not open, secret is NULL which may lead to a crash in secret_value_get_text
+      continue;
+    }
+
+    const gchar* secret_text = secret_value_get_text(secret);
+    char* password = NULL;
+    if (secret_text != NULL) {
+      password = strdup(secret_text);
+    }
 
     if (account == NULL || password == NULL) {
       if (account)


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

https://github.com/atom/node-keytar/issues/477

### Description of the Change

Ensure the variable `secret` is not NULL before passing it to the function `secret_value_get_text`. 

### Alternate Designs

An alternate design could be to use a `GCancellable` object in `secret_service_search_sync` function call. I tried to use it but failed to understand how to use it. 

### Possible Drawbacks

This MR should not add a possible drawback. 

### Verification Process

Test suite still pass (`npm run test`). 
Using `FindCredentials` without unlocking my keystore in my electron app does not crash anymore.

The error I got during my usage was:
```
  (process:280213): libsecret-CRITICAL **: 16:02:21.069: secret_value_get_text: assertion 'value' failed
```

### Release Notes

Fixed a bug where calling `FindCredentials` without unlocking the keystore on Linux. 

